### PR TITLE
Feat: downloadable info

### DIFF
--- a/app.html
+++ b/app.html
@@ -5,6 +5,7 @@
   </head>
   <body {{ BODY_ATTRS }}>
     {{ APP }}
+    <a id="downloadable_anchor"></a>
   </body>
   <script>
     var tableau = null

--- a/components/ShareableItems/ShareableItem.vue
+++ b/components/ShareableItems/ShareableItem.vue
@@ -73,6 +73,23 @@ export default {
     }
   },
 
+  computed: {
+    fileExtension () {
+      if (typeof this.downloadURL === 'string' && this.downloadURL.length) {
+        const ext = /(jpe?g|png|bmp|gif)/
+        const matched = ext.exec(this.downloadURL)
+        return matched ? matched[1] : null
+      }
+      return null
+    },
+    filename () {
+      if (!this.title || !this.fileExtension) {
+        return null
+      }
+      return `${this.title}.${this.fileExtension}`
+    }
+  },
+
   methods: {
     onDownload () {
       if (!this.downloadable || !this.downloadURL) {
@@ -85,8 +102,26 @@ export default {
         this.downloadFromFirebaseStorage(this.downloadURL)
       }
     },
+    saveBlob (blob, filename) {
+      if (!blob || !filename) {
+        return
+      }
+      const url = window.URL.createObjectURL(new Blob([blob]))
+      const anchor = document.getElementById('downloadable_anchor')
+      document.body.appendChild(anchor)
+      anchor.style = 'display: none'
+      anchor.href = url
+      anchor.download = filename
+      anchor.click()
+      window.URL.revokeObjectURL(url)
+    },
     downloadFromFirebaseStorage (publicURL) {
-      window.open(this.downloadURL, '_blank')
+      fetch(publicURL)
+        .then((response) => {
+          return response.blob()
+        }).then((blob) => {
+          this.saveBlob(blob, this.filename)
+        })
     },
     onShare () {
       const url = `whatsapp://send?text=${this.shareText}`

--- a/components/ShareableItems/ShareableItem.vue
+++ b/components/ShareableItems/ShareableItem.vue
@@ -76,7 +76,7 @@ export default {
   computed: {
     fileExtension () {
       if (typeof this.downloadURL === 'string' && this.downloadURL.length) {
-        const ext = /(jpe?g|png|bmp|gif)/
+        const ext = /(jpe?g|png|bmp|gif|docx?|pdf|xls?|pptx?)/
         const matched = ext.exec(this.downloadURL)
         return matched ? matched[1] : null
       }


### PR DESCRIPTION
note:
- typeof file extension is hardcoded in app. `next`: type must be inferred from filename. 