### PR TITLE
temporary fix: ensure berita jabar link is clickable

### DIFF
--- a/api/news.js
+++ b/api/news.js
@@ -1,7 +1,7 @@
 import _kebabCase from 'lodash/kebabCase'
 import { db } from '~/lib/firebase'
 
-function slugify (id, title) {
+export function slugify (id, title) {
   if (!id || !title) {
     console.error('slugify: id and title must be supplied')
     return '#'

--- a/components/ArticleList.vue
+++ b/components/ArticleList.vue
@@ -58,6 +58,7 @@
 
 <script>
 import { ContentLoader } from 'vue-content-loader'
+import { slugify } from '~/api/news'
 import { db, analytics } from '~/lib/firebase'
 import { formatDateTimeShort } from '~/lib/date'
 
@@ -134,7 +135,8 @@ export default {
               docs.push({
                 ...data,
                 id: doc.id,
-                published_at: data.published_at.toDate()
+                published_at: data.published_at.toDate(),
+                route: slugify(doc.id, data.title)
               })
             })
           }


### PR DESCRIPTION
Terjadi karena konversi slug hanya terjadi pada ~/api/news.js.
Sedangkan komponen [ArticleList](https://github.com/jabardigitalservice/pikobar-jabarprov-go-id/blob/master/components/ArticleList.vue) meng-consume firebase instance secara langsung.

next:
- Buat method consume untuk flow 'Load More' pada ~/api/news.js -> [Issue #54 ](https://github.com/jabardigitalservice/pikobar-jabarprov-go-id/issues/54)