### PR TITLE
[hotfix] CashDonation: include creation timestamp in payload

### DIFF
--- a/components/_pages/donate/FundParticipationForm.vue
+++ b/components/_pages/donate/FundParticipationForm.vue
@@ -179,9 +179,10 @@
 import { faCheckCircle, faTrash, faFileDownload, faFileUpload } from '@fortawesome/free-solid-svg-icons'
 import VueRecaptcha from 'vue-recaptcha'
 import Swal from 'sweetalert2'
-import { storage, db } from '@/lib/firebase'
+import { storage, db, Timestamp } from '@/lib/firebase'
 
 const emptyPayload = {
+  created_at: Timestamp.fromDate(new Date()),
   entity_type: '', // 'personal' | 'organization' | 'company'
   name: null,
   address: null,


### PR DESCRIPTION
include `created_at` as creation timestamp in POST data payload