### PR TITLE
Content: fix document and infographics pgination

### DIFF
--- a/components/ShareableItemTable/index.vue
+++ b/components/ShareableItemTable/index.vue
@@ -55,6 +55,16 @@
           </tr>
         </tbody>
       </table>
+      <br>
+      <div class="flex justify-center items-center">
+        <button
+          v-if="showLoadMore"
+          class="w-full lg:w-1/3 px-6 py-2 rounded-lg bg-brand-blue hover:bg-blue-400 text-white font-bold uppercase tracking-wider"
+          @click="onLoadMore"
+        >
+          Load More
+        </button>
+      </div>
     </slot>
   </div>
 </template>
@@ -72,6 +82,10 @@ export default {
     items: {
       type: Array,
       default: () => []
+    },
+    showLoadMore: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -98,6 +112,9 @@ export default {
     },
     beforeShare (item) {
       onShare(item.shareText)
+    },
+    onLoadMore () {
+      this.$emit('load:more')
     }
   }
 }

--- a/lib/download-and-share-firestore-doc.js
+++ b/lib/download-and-share-firestore-doc.js
@@ -1,6 +1,6 @@
 function getFileExtension (url) {
   if (typeof url === 'string' && url.length) {
-    const ext = /(jpe?g|png|bmp|gif|docx?|pdf|xls?|pptx?)/
+    const ext = /(jpe?g|png|bmp|gif|docx?|pdf|xls?|pptx?)\?/
     const matched = ext.exec(url)
     return matched ? matched[1] : null
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -520,7 +520,6 @@ export default {
     },
     shareableDocuments () {
       return this.documents
-        .filter((_, index) => index < 6)
         .map((item) => {
           return {
             ...item,

--- a/pages/info/documents/index.vue
+++ b/pages/info/documents/index.vue
@@ -14,6 +14,8 @@
       <ShareableItemTable
         :columns="shareableDocumentsColumns"
         :items="shareableDocuments"
+        :show-load-more="true"
+        @load:more="onLoadMore"
       />
     </section>
   </div>
@@ -63,7 +65,6 @@ export default {
     },
     shareableDocuments () {
       return this.documents
-        .filter((_, index) => index < 6)
         .map((item) => {
           return {
             ...item,
@@ -75,7 +76,7 @@ export default {
   },
   mounted () {
     this.isPending = true
-    this.getItems({ perPage: 8, fresh: true })
+    this.getItems({ fresh: true })
       .finally(() => {
         if (process.browser) {
           analytics.logEvent('documents_list_view')
@@ -89,6 +90,9 @@ export default {
     }),
     getCellValue (column, row, columnIndex, rowIndex) {
       return _get(row, column.prop)
+    },
+    onLoadMore () {
+      this.getItems({ fresh: true })
     }
   },
   head () {

--- a/pages/info/infographics/index.vue
+++ b/pages/info/infographics/index.vue
@@ -86,24 +86,23 @@ export default {
     })
   },
   mounted () {
-    this.loadData({ sendAnalytics: true })
+    this.isPending = true
+    this.getItems({ perPage: 9, fresh: true })
+      .finally(() => {
+        if (process.browser) {
+          analytics.logEvent('infographic_list_view')
+        }
+        this.isPending = false
+      })
   },
   methods: {
     ...mapActions('infographics', {
       getItems: 'getItems'
     }),
-    loadData ({ sendAnalytics = false } = {}) {
+    async onLoadMore () {
       this.isPending = true
-      this.getItems({ perPage: 9, fresh: true })
-        .finally(() => {
-          if (sendAnalytics && process.browser) {
-            analytics.logEvent('infographic_list_view')
-          }
-          this.isPending = false
-        })
-    },
-    onLoadMore () {
-      this.loadData()
+      await this.getItems({ perPage: 9, fresh: true })
+      this.isPending = false
     },
     beforeDownload (item) {
       onDownload(item.downloadURL, item.title)

--- a/store/infographics.js
+++ b/store/infographics.js
@@ -19,15 +19,15 @@ export const getters = {
 
 export const mutations = {
   setItems (state, items) {
-    const uniq = _uniqBy([...state.items, ...items], 'id')
-    const ordered = _orderBy(uniq, [ORDER_INDEX], [ORDER_TYPE])
-    state.items = ordered
+    state.items = items
   },
   clearItems (state) {
     state.items = []
   },
   appendItems (state, items) {
-    state.items = [...state.items, ...items]
+    const uniq = _uniqBy([...state.items, ...items], 'id')
+    const ordered = _orderBy(uniq, [ORDER_INDEX], [ORDER_TYPE])
+    state.items = ordered
   },
   prependItems (state, items) {
     state.items = [...items, ...state.items]
@@ -45,8 +45,12 @@ export const actions = {
         lastSnapshot: state.lastSnapshot
       })
         .then(({ data, lastSnapshot }) => {
-          commit('appendItems', data)
-          commit('setLastSnapshot', lastSnapshot)
+          if (process.client || process.browser) {
+            commit('appendItems', data)
+            commit('setLastSnapshot', lastSnapshot)
+          } else {
+            commit('setItems', data)
+          }
           return state.items
         })
     }


### PR DESCRIPTION
Bugfixes:
- Downloaded document extension is now inferred correctly
- Document list is no longer duplicated when going from homepage `/` to documents `/info/documents`
- Infographics list is no longer duplicated when going from homepage `/` to documents `/info/infographics`

Added:
- `Load More` button on documents page `/info/documents`