### PR TITLE
Fix: TabLayout active tab item marker is not properly rendered when viewport size changed

### DIFF
--- a/components/TabLayoutV2/TabLayout.vue
+++ b/components/TabLayoutV2/TabLayout.vue
@@ -93,12 +93,19 @@ export default {
   async mounted () {
     await this.$nextTick()
     this.syncActiveMarker()
+    window.addEventListener('resize', this.handleViewportResize)
+  },
+  beforeDestroy () {
+    window.removeEventListener('resize', this.handleViewportResize)
   },
   methods: {
     onClickTabItem (tab, tabIndex) {
       this.mValue = tabIndex
       this.$emit('change', tabIndex)
       this.$emit('click:tab', tab, tabIndex)
+    },
+    handleViewportResize () {
+      this.updateActiveMarker(this.mValue)
     },
     syncActiveMarker () {
       this.$watch(
@@ -107,12 +114,12 @@ export default {
         },
         async function handler (v) {
           await this.$nextTick()
-          this.moveActiveMarker(v)
+          this.updateActiveMarker(v)
         },
         { immediate: true }
       )
     },
-    moveActiveMarker (tabIndex) {
+    updateActiveMarker (tabIndex) {
       const track = this.$refs.itemTrack
       const tabEl = this.$refs.tabItems?.[tabIndex].$el
 


### PR DESCRIPTION
### Bug
Active tab marker is not properly rendered when viewport size changed at runtime.

https://user-images.githubusercontent.com/20709202/131082079-7930de86-b766-4fcd-88e7-91a4dd8bc032.mp4

### Fix
Listen to viewport resize event, and update active marker accordingly.

https://user-images.githubusercontent.com/20709202/131082315-88405050-d729-41a4-85cd-51d6f194b681.mp4



