### PR TITLE
Create ImageCarousel wrapper for banners and infographics; Insert InfographicsCarousel onto tab layout;

### DIFF
--- a/components/Homepage/BannerCarousel/index.vue
+++ b/components/Homepage/BannerCarousel/index.vue
@@ -2,6 +2,7 @@
   <ImageCarousel
     :items="banners"
     :loading="loading"
+    @click:slide="onClickSlide"
   />
 </template>
 
@@ -31,6 +32,19 @@ export default {
   },
   mounted () {
     this.$store.dispatch('banners/getItems')
+  },
+  methods: {
+    onClickSlide (slide) {
+      const { route } = slide
+      if (typeof route !== 'string' || !route.length) {
+        return
+      }
+      if (route.startsWith('http')) {
+        return window.open(route, '_blank')
+      } else {
+        return this.$router.push(route)
+      }
+    }
   }
 }
 </script>

--- a/components/Homepage/BannerCarousel/index.vue
+++ b/components/Homepage/BannerCarousel/index.vue
@@ -9,7 +9,7 @@
 import { mapState } from 'vuex'
 import { ImageCarousel } from '~/components/ImageCarouselV2'
 export default {
-  name: 'HomepageImageCarousel',
+  name: 'HomepageBannerCarousel',
   components: {
     ImageCarousel
   },

--- a/components/Homepage/InfographicAndDocument/index.vue
+++ b/components/Homepage/InfographicAndDocument/index.vue
@@ -6,9 +6,7 @@
         Info yang memuat infografis terkait Covid-19
       </p>
       <div class="mt-10">
-        <!--
-          TODO: insert infographic list view
-        -->
+        <InfographicCarousel />
       </div>
     </template>
     <template #content.document>
@@ -25,6 +23,7 @@
 </template>
 
 <script>
+import InfographicCarousel from '../InfographicCarousel'
 import DocumentTable from '../DocumentTable'
 import { TabLayout } from '~/components/TabLayoutV2'
 
@@ -32,6 +31,7 @@ export default {
   name: 'HomepageInfographicAndDocument',
   components: {
     TabLayout,
+    InfographicCarousel,
     DocumentTable
   },
   data () {

--- a/components/Homepage/InfographicCarousel/index.vue
+++ b/components/Homepage/InfographicCarousel/index.vue
@@ -1,0 +1,91 @@
+<template>
+  <ImageCarousel
+    class="infographic-carousel"
+    :items="infographics"
+    :loading="loading"
+    :swiper-props="swiperProps"
+    @click:slide="onClickSlide"
+  />
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import { ImageCarousel } from '~/components/ImageCarouselV2'
+export default {
+  name: 'HomepageInfographicCarousel',
+  components: {
+    ImageCarousel
+  },
+  data () {
+    return {
+      swiperProps: Object.freeze({
+        navigation: false,
+        centeredSlides: false,
+        spaceBetween: 16,
+        breakpoints: {
+          480: {
+            slidesPerView: 2.25,
+            centeredSlides: false,
+            navigation: false
+          },
+          640: {
+            slidesPerView: 3.25,
+            centeredSlides: false,
+            navigation: false
+          },
+          1024: {
+            slidesPerView: 4,
+            centeredSlides: false,
+            navigation: false
+          }
+        }
+      })
+    }
+  },
+  computed: {
+    ...mapState({
+      infographics: (state) => {
+        const items = state.infographics?.items || []
+        return items.map(item => ({
+          ...item,
+          src: item.downloadURL,
+          alt: item.title,
+          caption: item.title
+        }))
+      }
+    }),
+    loading () {
+      return !Array.isArray(this.infographics) ||
+        !this.infographics.length
+    }
+  },
+  mounted () {
+    this.$store.dispatch('infographics/getItems', {
+      perPage: 4
+    })
+  },
+  methods: {
+    onClickSlide (slide) {
+      const { route } = slide
+      if (typeof route !== 'string' || !route.length) {
+        return
+      }
+      if (route.startsWith('http')) {
+        return window.open(route, '_blank')
+      } else {
+        return this.$router.push(route)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.infographic-carousel::v-deep {
+  .image-carousel__swiper-slide {
+    @apply overflow-hidden
+    border border-solid border-gray-300
+    rounded-lg;
+  }
+}
+</style>


### PR DESCRIPTION
### Task Description
Create and/or adjust ImageCarousel wrapper for banners and infographics in homepage

### Changes
- Rename `components/Homepage/ImageCarousel` to `components/Homepage/BannerCarousel` for better context
- Make BannerCarousel slide clickable
- Create ImageCarousel wrapper for infographics
- Insert InfographicsCarousel onto homepage tab layout

### Preview

https://user-images.githubusercontent.com/20709202/131465549-740c9317-a458-4132-aa91-aed0c5811247.mp4

