### PR TITLE
Create carousel view for news item for use in homepage

### DIFF
--- a/components/Homepage/RecentNewsCarousel/index.vue
+++ b/components/Homepage/RecentNewsCarousel/index.vue
@@ -1,0 +1,39 @@
+<template>
+  <NewsCarousel
+    :items="news"
+    :loading="loading"
+  />
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import { NewsCarousel } from '~/components/NewsCarousel'
+export default {
+  components: {
+    NewsCarousel
+  },
+  computed: {
+    ...mapState({
+      news: (state) => {
+        const items = state.news?.items || []
+        return items.map(item => ({
+          ...item,
+          thumbnail: item.image,
+          date: item.published_at,
+          source: item.news_channel,
+          url: item.route
+        }))
+      }
+    }),
+    loading () {
+      return !Array.isArray(this.news) ||
+        !this.news.length
+    }
+  },
+  mounted () {
+    this.$store.dispatch('news/getItems', {
+      perPage: 4
+    })
+  }
+}
+</script>

--- a/components/Homepage/RecentNewsCarousel/index.vue
+++ b/components/Homepage/RecentNewsCarousel/index.vue
@@ -9,6 +9,7 @@
 import { mapState } from 'vuex'
 import { NewsCarousel } from '~/components/NewsCarousel'
 export default {
+  name: 'RecentNewsCarousel',
   components: {
     NewsCarousel
   },

--- a/components/NewsCarousel/NewsCarousel.vue
+++ b/components/NewsCarousel/NewsCarousel.vue
@@ -1,0 +1,89 @@
+<template>
+  <ImageCarousel
+    class="news-carousel"
+    :items="items"
+    :loading="loading"
+    :swiper-props="swiperProps"
+    @click:slide="onClickSlide"
+  >
+    <template #item="{ item }">
+      <NewsCarouselItem v-bind="item" />
+    </template>
+  </ImageCarousel>
+</template>
+
+<script>
+import NewsCarouselItem from './NewsCarouselItem'
+import { ImageCarousel } from '~/components/ImageCarouselV2'
+
+export default {
+  name: 'NewsCarousel',
+  components: {
+    ImageCarousel,
+    NewsCarouselItem
+  },
+  props: {
+    /**
+     * Array of NewsCarouselItem's props.
+     * @See './NewsCarouselItem.vue'
+     */
+    items: {
+      type: Array,
+      default: () => []
+    },
+    loading: {
+      type: Boolean
+    }
+  },
+  data () {
+    return {
+      swiperProps: Object.freeze({
+        navigation: false,
+        centeredSlides: false,
+        spaceBetween: 16,
+        breakpoints: {
+          480: {
+            slidesPerView: 2.25,
+            centeredSlides: false,
+            navigation: false
+          },
+          640: {
+            slidesPerView: 3.25,
+            centeredSlides: false,
+            navigation: false
+          },
+          1024: {
+            slidesPerView: 4,
+            centeredSlides: false,
+            navigation: false
+          }
+        }
+      })
+    }
+  },
+  methods: {
+    onClickSlide (slide) {
+      const { route } = slide
+      if (typeof route !== 'string' || !route.length) {
+        return
+      }
+      if (route.startsWith('http')) {
+        return window.open(route, '_blank')
+      } else {
+        return this.$router.push(route)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.news-carousel::v-deep {
+  .swiper-wrapper {
+    @apply flex-row flex-no-wrap items-stretch;
+  }
+  .swiper-slide {
+    @apply h-auto;
+  }
+}
+</style>

--- a/components/NewsCarousel/NewsCarousel.vue
+++ b/components/NewsCarousel/NewsCarousel.vue
@@ -4,7 +4,6 @@
     :items="items"
     :loading="loading"
     :swiper-props="swiperProps"
-    @click:slide="onClickSlide"
   >
     <template #item="{ item }">
       <NewsCarouselItem v-bind="item" />
@@ -59,19 +58,6 @@ export default {
           }
         }
       })
-    }
-  },
-  methods: {
-    onClickSlide (slide) {
-      const { route } = slide
-      if (typeof route !== 'string' || !route.length) {
-        return
-      }
-      if (route.startsWith('http')) {
-        return window.open(route, '_blank')
-      } else {
-        return this.$router.push(route)
-      }
     }
   }
 }

--- a/components/NewsCarousel/NewsCarouselItem.vue
+++ b/components/NewsCarousel/NewsCarouselItem.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="news-carousel-item">
+    <img
+      class="news-carousel-item__img"
+      :src="thumbnail"
+      @click="goToUrl"
+    >
+    <div class="news-carousel-item__body">
+      <span class="news-carousel-item__source">
+        {{ source }}
+      </span>
+      <a
+        class="news-carousel-item__title"
+        @click="goToUrl"
+      >
+        <strong>
+          {{ title }}
+        </strong>
+      </a>
+    </div>
+    <time
+      :date="date"
+      class="news-carousel-item__date"
+    >
+      {{ formattedDate }}
+    </time>
+  </div>
+</template>
+
+<script>
+import { formatDateIndonesia } from '../../lib/date'
+export default {
+  inheritAttrs: false,
+  props: {
+    title: {
+      type: String,
+      default: null
+    },
+    thumbnail: {
+      type: String,
+      default: null
+    },
+    date: {
+      type: [String, Date],
+      default: null
+    },
+    source: {
+      type: String,
+      default: null
+    },
+    url: {
+      type: String,
+      default: null
+    }
+  },
+  computed: {
+    formattedDate () {
+      return this.date
+        ? formatDateIndonesia(this.date)
+        : ''
+    }
+  },
+  methods: {
+    goToUrl () {
+      const { url } = this
+      if (typeof url !== 'string' || !url.length) {
+        return
+      }
+      if (url.startsWith('http')) {
+        return window.open(url, '_blank')
+      } else {
+        return this.$router.push(url)
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.news-carousel-item {
+  line-height: 1.618;
+
+  @apply overflow-hidden h-full
+  flex flex-col flex-no-wrap
+  justify-start items-stretch
+  rounded-lg
+  border border-solid border-gray-200
+  bg-white;
+
+  &__img {
+    height: 150px;
+    justify-self: stretch;
+
+    @apply cursor-pointer
+    flex-none w-auto
+    object-cover object-center;
+
+    &:hover {
+      @apply opacity-75;
+    }
+  }
+
+  &__body {
+    @apply flex-1 m-4 mb-2;
+  }
+
+  &__source {
+    font-size: 10px;
+
+    @apply inline-block
+    mb-5 px-2 py-1
+    rounded-full
+    bg-blue-500
+    text-white font-medium;
+  }
+
+  &__title {
+    @apply cursor-pointer
+    block
+    text-sm font-medium;
+
+    &:hover {
+      @apply underline;
+    }
+  }
+
+  &__date {
+    font-size: 11px;
+
+    @apply block
+    m-4 mt-0
+    text-gray-600 font-bold;
+  }
+}
+</style>

--- a/components/NewsCarousel/NewsCarouselItem.vue
+++ b/components/NewsCarousel/NewsCarouselItem.vue
@@ -30,6 +30,7 @@
 <script>
 import { formatDateIndonesia } from '../../lib/date'
 export default {
+  name: 'NewsCarouselItem',
   inheritAttrs: false,
   props: {
     title: {

--- a/components/NewsCarousel/index.js
+++ b/components/NewsCarousel/index.js
@@ -1,0 +1,3 @@
+import NewsCarousel from './NewsCarousel'
+export { NewsCarousel }
+export default NewsCarousel


### PR DESCRIPTION
### Task Description
Carousel view previously is using VueCarousel. This PR replaced corresponding component base library with VueAwesomeSwiper, which is abstracted under `~/components/ImageCarouselV2`.

This is meant to ensure that news carousel view behaves exactly the same with infographics carousel view in homepage.

### Changes
- Create carousel item view: `NewsCarouselItem`
- Create carousel view: `NewsCarousel`
- Create carousel view wrapper for recent news use case in homepage: `RecentNewsCarousel`

### Notes
News carousel view in `/vaccine` route will also be replaced with `NewsCarousel` in the future.

### Preview

https://user-images.githubusercontent.com/20709202/131644948-752d5774-b1fa-4225-a41d-9d45cc387e16.mp4

