### PR TITLE
Refactor button into BaseButton

### DIFF
--- a/components/Base/Button/index.vue
+++ b/components/Base/Button/index.vue
@@ -1,0 +1,99 @@
+<template>
+  <component
+    :is="tag"
+    :class="{
+      'base-button': true,
+      'base-button--outlined': outlined,
+      'base-button--shadowed': shadowed
+    }"
+    :disabled="disabled"
+    v-bind="$attrs"
+  >
+    <span class="base-button__label">
+      <slot>
+        {{ label }}
+      </slot>
+    </span>
+    <i class="base-button__icon">
+      <slot name="icon" />
+    </i>
+  </component>
+</template>
+
+<script>
+/**
+ * As of now, only supports green color (filled or outlined).
+ */
+export default {
+  props: {
+    tag: {
+      type: String,
+      default: 'button'
+    },
+    label: {
+      type: String,
+      required: true
+    },
+    outlined: {
+      type: Boolean
+    },
+    disabled: {
+      type: Boolean
+    },
+    shadowed: {
+      type: Boolean
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.base-button {
+  @apply inline-flex flex-row flex-no-wrap gap-2
+  justify-around items-center
+  px-4 py-3
+  border border-solid border-transparent
+  rounded-lg
+  bg-brand-green-darker
+  text-white font-bold tracking-wide;
+
+  &--outlined {
+    @apply border-green-500
+    rounded-md
+    bg-white
+    text-green-700;
+  }
+
+  &--shadowed {
+    @apply shadow-sm;
+  }
+
+  &__label {
+    color: inherit;
+    font-size: inherit;
+    line-height: 1.618;
+
+    @apply flex-none;
+  }
+
+  &__icon {
+    line-height: 0;
+    @apply flex-none
+    inline-flex flex-row flex-no-wrap
+    justify-center items-center;
+  }
+
+  &:hover {
+    @apply opacity-75;
+  }
+
+  &:active {
+    @apply opacity-100;
+  }
+
+  &:focus,
+  &:active {
+    @apply outline-none;
+  }
+}
+</style>

--- a/components/Base/Button/index.vue
+++ b/components/Base/Button/index.vue
@@ -4,7 +4,7 @@
     :class="{
       'base-button': true,
       'base-button--outlined': outlined,
-      'base-button--shadowed': shadowed
+      'base-button--shadowed': shadowed || outlined
     }"
     :disabled="disabled"
     v-bind="$attrs"

--- a/components/Base/Button/index.vue
+++ b/components/Base/Button/index.vue
@@ -8,6 +8,7 @@
     }"
     :disabled="disabled"
     v-bind="$attrs"
+    v-on="$listeners"
   >
     <span class="base-button__label">
       <slot>

--- a/components/ContentCard/index.vue
+++ b/components/ContentCard/index.vue
@@ -135,27 +135,5 @@ export default {
     &__body {
       @apply mt-3 text-base;
     }
-
-    &__btn-link {
-      @apply inline-flex bg-brand-green-darker
-      text-white text-sm font-bold tracking-wide
-      px-3 py-3
-      rounded-lg
-      mt-6
-      gap-2
-      items-center
-      justify-around;
-
-      &-outline {
-        @apply inline-flex items-center px-3 py-2 border
-        border-green-500
-        shadow-sm
-        mt-6
-        gap-2
-        text-base
-        rounded-md
-        text-green-700
-      }
-    }
   }
 </style>

--- a/components/ContentCard/index.vue
+++ b/components/ContentCard/index.vue
@@ -15,29 +15,31 @@
           <p class="content-card__body text-black-500">
             {{ body }}
           </p>
-          <a
-            :href="backLink"
+          <BaseButton
+            tag="a"
             target="_blank"
-            :class="[buttonType ? 'content-card__btn-link-outline' : 'content-card__btn-link']"
+            :label="prompt"
+            :href="backLink"
+            :outlined="buttonType === 'outline'"
+            class="mt-6"
           >
-            <span>
-              {{ prompt }}
-            </span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              class="w-5 h-5 ml-3"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M14 5l7 7m0 0l-7 7m7-7H3"
-              />
-            </svg>
-          </a>
+            <template #icon>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="w-5 h-5 ml-3"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M14 5l7 7m0 0l-7 7m7-7H3"
+                />
+              </svg>
+            </template>
+          </BaseButton>
         </div>
       </div>
       <div v-if="imagePosition === 'right'" class="flex-1">
@@ -48,7 +50,11 @@
 </template>
 
 <script>
+import BaseButton from '~/components/Base/Button'
 export default {
+  components: {
+    BaseButton
+  },
   props: {
     header: {
       type: String,


### PR DESCRIPTION
### TaskDescription
Button has been developed by @Arif9878  and used in `ContentCard`.
Due to similar button occurence in some routes, button is then refactored into `BaseButton`.

### Changes 
- Replicate embedded button within `ContentCard` into `BaseButton`.
- Replace embedded button within `ContentCard` with `BaseButton`.

### Notes
- `BaseButton` supports only green color (filled or outlined), as specified in Figma.
- `BaseButton` icon can only be aligned right.

### Preview
#### Refactored Content Card

![Screenshot from 2021-09-07 12 19 22](https://user-images.githubusercontent.com/20709202/132289127-4a269216-ee9c-46ce-8cc3-231a249b3584.png)

![Screenshot from 2021-09-07 12 19 42](https://user-images.githubusercontent.com/20709202/132289144-df093452-5ca9-40fc-86b2-8f8760e04710.png)


