### PR TITLE
Add loading state for event statistics and recent news section in homepage

### DIFF
--- a/api/news.js
+++ b/api/news.js
@@ -47,3 +47,20 @@ export function getById (id) {
       return null
     })
 }
+
+/**
+ * Last update reflects of latest document inserted
+ * into firebase "articles" collections, without regard
+ * to article tag or category.
+ * @returns {Date | undefined} last update date
+ */
+export function getLastUpdate () {
+  return get({
+    perPage: 1,
+    tag: null
+  }).then((news) => {
+    const latest = Array.isArray(news) ? news[0] : null
+    // eslint-disable-next-line camelcase
+    return latest?.published_at
+  })
+}

--- a/api/news.js
+++ b/api/news.js
@@ -49,8 +49,8 @@ export function getById (id) {
 }
 
 /**
- * Last update reflects of latest document inserted
- * into firebase "articles" collections, without regard
+ * Last update reflects of the timestamp of the latest inserted
+ * document into firebase "articles" collections, without regard
  * to article tag or category.
  * @returns {Date | undefined} last update date
  */

--- a/components/Base/Section/Section.vue
+++ b/components/Base/Section/Section.vue
@@ -15,10 +15,11 @@
     >
       <slot name="header">
         <SectionHeader
-          v-if="title || subtitle"
+          vif="title || subtitle"
           :title="title"
           :subtitle="subtitle"
           :align="alignHeader"
+          :loading="loading"
         />
       </slot>
       <slot />
@@ -44,6 +45,9 @@ export default {
       default: true
     },
     noGutters: {
+      type: Boolean
+    },
+    loading: {
       type: Boolean
     },
 

--- a/components/Base/Section/Section.vue
+++ b/components/Base/Section/Section.vue
@@ -15,7 +15,7 @@
     >
       <slot name="header">
         <SectionHeader
-          vif="title || subtitle"
+          v-show="title || subtitle"
           :title="title"
           :subtitle="subtitle"
           :align="alignHeader"

--- a/components/Base/Section/SectionHeader.vue
+++ b/components/Base/Section/SectionHeader.vue
@@ -6,28 +6,24 @@
       'section-header--centered': align === 'center'
     }"
   >
-    <template v-if="loading">
-      <BaseSkeleton class="section-header__title-skeleton" />
-      <BaseSkeleton class="section-header__subtitle-skeleton" />
-    </template>
-    <template v-else>
-      <p
-        v-show="$slots.title || title"
-        class="section-header__title"
-      >
-        <slot name="title">
-          {{ title }}
-        </slot>
-      </p>
-      <p
-        v-show="$slots.subtitle || subtitle"
-        class="section-header__subtitle"
-      >
-        <slot name="subtitle">
-          {{ subtitle }}
-        </slot>
-      </p>
-    </template>
+    <BaseSkeleton v-show="loading" class="section-header__title-skeleton" />
+    <BaseSkeleton v-show="loading" class="section-header__subtitle-skeleton" />
+    <p
+      v-show="!loading && ($slots.title || title)"
+      class="section-header__title"
+    >
+      <slot name="title">
+        {{ title }}
+      </slot>
+    </p>
+    <p
+      v-show="!loading && ($slots.subtitle || subtitle)"
+      class="section-header__subtitle"
+    >
+      <slot name="subtitle">
+        {{ subtitle }}
+      </slot>
+    </p>
   </header>
 </template>
 

--- a/components/Base/Section/SectionHeader.vue
+++ b/components/Base/Section/SectionHeader.vue
@@ -6,28 +6,41 @@
       'section-header--centered': align === 'center'
     }"
   >
-    <p
-      v-show="$slots.title || title"
-      class="section-header__title"
-    >
-      <slot name="title">
-        {{ title }}
-      </slot>
-    </p>
-    <p
-      v-show="$slots.subtitle || subtitle"
-      class="section-header__subtitle"
-    >
-      <slot name="subtitle">
-        {{ subtitle }}
-      </slot>
-    </p>
+    <template v-if="loading">
+      <BaseSkeleton class="section-header__title-skeleton" />
+      <BaseSkeleton class="section-header__subtitle-skeleton" />
+    </template>
+    <template v-else>
+      <p
+        v-show="$slots.title || title"
+        class="section-header__title"
+      >
+        <slot name="title">
+          {{ title }}
+        </slot>
+      </p>
+      <p
+        v-show="$slots.subtitle || subtitle"
+        class="section-header__subtitle"
+      >
+        <slot name="subtitle">
+          {{ subtitle }}
+        </slot>
+      </p>
+    </template>
   </header>
 </template>
 
 <script>
+import BaseSkeleton from '~/components/BaseSkeleton'
 export default {
+  components: {
+    BaseSkeleton
+  },
   props: {
+    loading: {
+      type: Boolean
+    },
     align: {
       validator: (v) => {
         return ['center', 'left'].includes(v)
@@ -49,6 +62,7 @@ export default {
 <style lang="scss" scoped>
 .section-header {
   padding-bottom: 24px;
+  @apply flex flex-col flex-no-wrap;
 
   &__title {
     line-height: 1.618;
@@ -62,13 +76,22 @@ export default {
     text-gray-600 text-base font-normal;
   }
 
+  &__title-skeleton {
+    @apply w-1/3 h-6 mb-8
+    rounded-full;
+  }
+  &__subtitle-skeleton {
+    @apply w-2/3 h-6
+    rounded-full;
+  }
+
   &,
   &--centered {
-    @apply text-center;
+    @apply items-center;
   }
 
   &--left {
-    @apply text-left;
+    @apply items-start;
   }
 
   @screen md {

--- a/components/Homepage/EventStatistics/index.vue
+++ b/components/Homepage/EventStatistics/index.vue
@@ -55,11 +55,12 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 import {
   transformToTopStatisticsData,
   transformToBottomStatisticsData
 } from './data.utils'
+import { formatDateTimeShort } from '~/lib/date'
 
 import {
   EventStatCard,
@@ -72,12 +73,22 @@ export default {
     EventStatCardCounter
   },
   computed: {
-    ...mapGetters('data-kasus-total-v2', {
-      dataJabar: 'itemsMap',
+    ...mapState('data-kasus-total-v2', {
+      /**
+       * @public
+       */
+      lastUpdate: (state) => {
+        // eslint-disable-next-line camelcase
+        const date = state.metadata?.last_update
+        return date
+          ? formatDateTimeShort(new Date(date))
+          : null
+      },
+      dataJabar: 'items',
       isLoadingDataJabar: 'isLoading'
     }),
-    ...mapGetters('covid-cases-national', {
-      dataNational: 'itemsMap',
+    ...mapState('covid-cases-national', {
+      dataNational: 'items',
       isLoadingDataNational: 'isLoading'
     }),
     topStats () {
@@ -91,6 +102,13 @@ export default {
     }
   },
   mounted () {
+    this.$watch(
+      'isLoading',
+      function (v) {
+        this.$emit('loading', v)
+      },
+      { immediate: true }
+    )
     this.getCovidCasesNational()
     this.getDataKasusTotalV2()
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,7 +24,10 @@
       class="py-20 bg-gray-50"
       v-bind="section.eventStatistics"
     >
-      <EventStatistics />
+      <EventStatistics
+        ref="eventStatistics"
+        @loading="onSectionLoad('eventStatistics', $event)"
+      />
       <div class="mt-6 md:mt-10 flex flex-row justify-center">
         <ContentCardButton v-bind="button.eventStatistics" />
       </div>
@@ -41,7 +44,10 @@
       class="py-20 bg-gray-50"
       v-bind="section.recentNews"
     >
-      <RecentNewsCarousel />
+      <RecentNewsCarousel
+        ref="recentNews"
+        @loading="onSectionLoad('recentNews', $event)"
+      />
       <div class="mt-6 md:mt-10 flex flex-row justify-center">
         <ContentCardButton v-bind="button.recentNews" />
       </div>
@@ -69,6 +75,7 @@
     </Section>
   </div>
 </template>
+
 <script>
 import { analytics } from '~/lib/firebase'
 import TopAlert from '~/components/TopAlert'
@@ -102,12 +109,14 @@ export default {
       },
       section: {
         eventStatistics: {
+          loading: true,
           title: 'Angka Kejadian Di Jawa Barat',
-          subtitle: 'Update Terakhir: 8 September 00.00'
+          subtitle: null
         },
         recentNews: {
+          loading: true,
           title: 'Berita Terkini',
-          subtitle: 'Update Terakhir: 8 September 00.00'
+          subtitle: null
         },
         miscInfo: {
           title: 'Informasi Lainnya',
@@ -188,6 +197,15 @@ export default {
         analytics.logEvent('homepage_view')
       }
     })
+  },
+  methods: {
+    onSectionLoad (name, isLoading) {
+      const { lastUpdate } = this.$refs[name] || []
+      this.section[name].loading = isLoading
+      this.section[name].subtitle = isLoading
+        ? null
+        : `Update Terakhir: ${lastUpdate}`
+    }
   }
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -200,11 +200,11 @@ export default {
   },
   methods: {
     onSectionLoad (name, isLoading) {
-      const { lastUpdate } = this.$refs[name] || []
+      const { lastUpdate } = this.$refs[name]
       this.section[name].loading = isLoading
-      this.section[name].subtitle = isLoading
-        ? null
-        : `Update Terakhir: ${lastUpdate}`
+      this.section[name].subtitle = !isLoading && lastUpdate
+        ? `Update Terakhir: ${lastUpdate}`
+        : null
     }
   }
 }

--- a/store/news.js
+++ b/store/news.js
@@ -1,9 +1,20 @@
 import _uniqBy from 'lodash/uniqBy'
 import _orderBy from 'lodash/orderBy'
-import { get, getById, ORDER_INDEX, ORDER_TYPE } from '~/api/news'
+import {
+  get,
+  getById,
+  getLastUpdate as __getLastUpdate,
+  ORDER_INDEX,
+  ORDER_TYPE
+} from '~/api/news'
 
 export const state = () => ({
-  items: []
+  items: [],
+
+  /**
+   * @type {Date | null}
+   */
+  lastUpdate: null
 })
 
 export const getters = {
@@ -16,6 +27,9 @@ export const getters = {
 }
 
 export const mutations = {
+  setLastUpdate (state, date) {
+    state.lastUpdate = date
+  },
   setItems (state, items) {
     const uniq = _uniqBy([...state.items, ...items], 'id')
     const ordered = _orderBy(uniq, [ORDER_INDEX], [ORDER_TYPE])
@@ -53,5 +67,12 @@ export const actions = {
         commit('setItems', [...state.items, item])
         return getters.itemsMap[id]
       })
+  },
+  async getLastUpdate ({ state, commit }) {
+    if (!state.lastUpdate) {
+      const date = await __getLastUpdate()
+      commit('setLastUpdate', date)
+    }
+    return state.lastUpdate
   }
 }


### PR DESCRIPTION
### Task Description
#### Related PR: #357 
Both event statistics and recent news last update text view on above PR is still hardcoded. Also, both currently has no loading state handler. This PR address that issue.


### Changes
- Add and handle loading state in section header.
- Add `getLastUpdate` XHR for firestore/articles collection
- Add `getLastUpdate` Vuex Action for vuex/news module
- Keep `lastUpdate` for both event statistics and recent news in each component state
- Expose loading state of each view using event
- Use `$refs` to access exposed `lastUpdate` value of each view on parent component (`pages/index`)

### Preview

https://user-images.githubusercontent.com/20709202/132638216-04b7400e-352e-49c1-b953-707c1cc4c194.mp4


