### PR TITLE
ImageCarousel drag gesture and layout improvement 

### DIFF
--- a/components/ImageCarouselV2/ImageCarousel.vue
+++ b/components/ImageCarouselV2/ImageCarousel.vue
@@ -193,8 +193,7 @@ export default {
       // sorted and reversed due to
       // min-width matching strategy
       const sorted = [...this.swiperBreakpoints]
-        .sort((a, b) => a - b)
-        .reverse()
+        .sort((a, b) => b - a)
 
       return sorted.find((width, i) => {
         // first index is widest breakpoint

--- a/components/ImageCarouselV2/ImageCarousel.vue
+++ b/components/ImageCarouselV2/ImageCarousel.vue
@@ -196,12 +196,12 @@ export default {
         .sort((a, b) => a - b)
         .reverse()
 
-      return sorted.find((width, i, coll) => {
+      return sorted.find((width, i) => {
         // first index is widest breakpoint
         if (i === 0) {
           return window.innerWidth >= width
         }
-        const [min, max] = [coll[i + 1], width]
+        const [min, max] = [width, sorted[i - 1]]
         return _inRange(window.innerWidth, min, max)
       })
     },


### PR DESCRIPTION
### Task Description
Carousel can now bleed fully edge to-edge within a page.
Carousel is only draggable if total slide is greater than the configured slides per view.

### Changes
- Carousel is configurable to responsively bleed using `swiperProps` attribute.
- Automatically compute whether dragging is allowed by comparing expected slides per view `vs` total slides length
- Refactor navigation visibility handler

### Preview
#### Before (Clipped Carousel)
![Screenshot from 2021-09-10 10 36 13](https://user-images.githubusercontent.com/20709202/132795573-2c1ca96b-c362-4242-8f18-ecac51976779.png)


#### After (Edge-to-edge Carousel)

https://user-images.githubusercontent.com/20709202/132795489-1f1c99d8-8919-479a-85ef-4898fb32cad5.mp4

