### PR TITLE
Fix: Handle homepage backlink navigation by detecting its link type (internal, external, hash anchor)

### DIFF
--- a/components/ContentCard/ContentCardButton.vue
+++ b/components/ContentCard/ContentCardButton.vue
@@ -1,10 +1,10 @@
 <template>
   <BaseButton
     tag="a"
-    target="_blank"
     :label="prompt"
     :href="backLink"
     :outlined="buttonType === 'outline'"
+    @click.prevent="onClick"
   >
     <template #icon>
       <svg
@@ -44,6 +44,48 @@ export default {
     buttonType: {
       type: String,
       default: ''
+    }
+  },
+  methods: {
+    /**
+     * NOTES:
+     * this function should've provided most common cases of link handling.
+     * might be wise to refactor this function onto "~/lib".
+     */
+    onClick () {
+      const { backLink } = this
+      if (typeof backLink !== 'string' || !backLink.length) {
+        return
+      }
+      // for external link
+      if (backLink.startsWith('http')) {
+        return window.open(backLink, '_blank', 'noreferrer,noopener')
+      }
+
+      // for internal link
+      if (backLink.startsWith('/')) {
+        return this.$router.push(backLink)
+      }
+
+      // for anchor within page
+      if (backLink.startsWith('#')) {
+        // NOTES:
+        // this won't work if there exists a sticky element outside of appbar
+        const appbar = document.querySelector('header.appbar')
+        const target = document.querySelector(this.backLink)
+        if (!appbar || !target) {
+          return
+        }
+        const { height: appbarHeight } = appbar.getBoundingClientRect()
+        const { top: targetTop } = target.getBoundingClientRect()
+
+        // subtracted by appbarHeight due to appbar's sticky position
+        const position = targetTop - appbarHeight + window.scrollY
+        return window.scrollTo({
+          behavior: 'smooth',
+          top: position
+        })
+      }
     }
   }
 }

--- a/components/ContentCard/ContentCardButton.vue
+++ b/components/ContentCard/ContentCardButton.vue
@@ -57,7 +57,8 @@ export default {
       if (typeof backLink !== 'string' || !backLink.length) {
         return
       }
-      // for external link
+      // for external link.
+      // will always open in new tab with WindowFeatures "noopener, noreferrer"
       if (backLink.startsWith('http')) {
         return window.open(backLink, '_blank', 'noreferrer,noopener')
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -21,6 +21,7 @@
       <BannerCarousel />
     </Section>
     <Section
+      id="eventStatistics"
       class="py-20 bg-gray-50"
       v-bind="section.eventStatistics"
     >
@@ -129,7 +130,7 @@ export default {
           body: 'Media komunikasi dan informasi penanganan Covid-19 satu pintu di Jawa Barat. Hadirkan data dan visualisasi perkembangan kasus terkini Covid-19. Dilengkapi ragam layanan kesehatan digital pendukung kedaruratan pandemi.',
           image: '/img/icon-hero.svg',
           imagePosition: 'right',
-          backLink: '/',
+          backLink: '#eventStatistics',
           prompt: 'Selanjutnya'
         },
         {
@@ -166,25 +167,21 @@ export default {
       button: {
         eventStatistics: {
           backLink: '/data',
-          target: '_self',
           prompt: 'Selengkapnya',
           buttonType: 'outline'
         },
         recentNews: {
           backLink: '/articles?tab=jabar',
-          target: '_self',
           prompt: 'Lihat Berita Selengkapnya',
           buttonType: 'outline'
         },
         infographics: {
-          backLink: '/articles?tab=jabar',
-          target: '_self',
+          backLink: '/info/infographics',
           prompt: 'Lihat Selengkapnya',
           buttonType: 'outline'
         },
         documents: {
           backLink: '/info/documents',
-          target: '_self',
           prompt: 'Lihat Selengkapnya',
           buttonType: 'outline'
         }


### PR DESCRIPTION
### Task Description
Previously, ContentCardButton link is always treated as an external one, by which clicking on the button will request a full page load.
This PR address the above issue.

### Changes
- Ensure internal link is treated as in-app navigation (SPA).
- Ensure external link is always opened in new tab with `WindowFeatures` `noopener,noreferrer`.
- Make helper to scroll onto hash anchor, e.g `<div id="#scrollTarget" />`
- Fix infographics view backlink

### Preview
#### Internal Link

https://user-images.githubusercontent.com/20709202/132809466-55d455ad-f830-494c-badd-138b4282fc54.mp4

#### External Link
*link to google.com is setup for previewing purpose only

https://user-images.githubusercontent.com/20709202/132809646-6cfa8ba1-9244-4212-8fbe-87b20c38bbc1.mp4

#### Hash Anchor

https://user-images.githubusercontent.com/20709202/132809468-ff8ffca2-d3a0-44a1-9939-3cbaaac6fa24.mp4

***

title: Memperbaiki navigasi di homepage dengan mendeteksi tipe link yang digunakan
project: Pikobar Website
participants: @adrian.pdmh @yoslie @adzharamrullah @Ibwedagama @ihsannaufalk @maulanayuseph 