### PR TITLE
Create hospitals and call centers view

### DIFF
--- a/components/Base/ContactCard/ContactCardChip.vue
+++ b/components/Base/ContactCard/ContactCardChip.vue
@@ -1,6 +1,7 @@
 <template>
   <a
     :href="href"
+    :disabled="disabled || !href"
     class="contact-card-chip"
     @click.prevent="onClick"
   >
@@ -41,6 +42,9 @@ export default {
     href: {
       type: String,
       default: null
+    },
+    disabled: {
+      type: Boolean
     }
   },
   data () {
@@ -106,12 +110,19 @@ export default {
     }
   }
 
-  &:hover {
-    @apply bg-gray-300;
+  &:not(:disabled):not([disabled]) {
+    &:hover {
+      @apply bg-gray-300;
+    }
+
+    &:active {
+      @apply bg-gray-200;
+    }
   }
 
-  &:active {
-    @apply bg-gray-200;
+  &:disabled,
+  &[disabled] {
+    @apply cursor-not-allowed;
   }
 }
 </style>

--- a/components/KenaliCovid/HospitalsAndCallCenters/CallCenters.vue
+++ b/components/KenaliCovid/HospitalsAndCallCenters/CallCenters.vue
@@ -1,0 +1,89 @@
+<template>
+  <WrapperItem v-bind="$data">
+    <template v-for="(item, i) in list">
+      <ContactCard
+        :key="i"
+        v-bind="item"
+        class="mt-6"
+      />
+    </template>
+  </WrapperItem>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import { toPhoneURL, toArray, fillArrayIfEmpty } from './utils'
+import WrapperItem from './WrapperItem'
+import { ContactCard } from '~/components/Base/ContactCard'
+
+export default {
+  components: {
+    WrapperItem,
+    ContactCard
+  },
+  data () {
+    return Object.freeze({
+      title: 'Hubungi Call Center',
+      body: `
+        Apabila Anda mengalami atau menemukan kejanggalan seputar Covid-19,
+        segera hubungi nomor di bawah ini.
+      `,
+      buttonLink: '/contact'
+    })
+  },
+  computed: {
+    ...mapState('call-centers', {
+      isLoading: (state) => {
+        return !Array.isArray(state.items) ||
+          !state.items.length
+      }
+    }),
+    list () {
+      if (this.isLoading) {
+        return []
+      }
+      const { items } = this.$store.state['call-centers']
+      return items.map(this.mapCallCenteritem)
+    }
+  },
+  mounted () {
+    this.$store.dispatch('call-centers/getItems', { perPage: 3 })
+  },
+  methods: {
+    mapCallCenteritem (item) {
+      const callCenters = {
+        name: 'Call Center',
+        contacts: []
+      }
+      const hotlines = {
+        name: 'Hotline',
+        contacts: []
+      }
+
+      try {
+        callCenters.contacts = toArray(item.call_center)
+          .map(cc => ({
+            icon: 'phone',
+            label: cc,
+            href: toPhoneURL(cc)
+          }))
+        hotlines.contacts = toArray(item.hotline)
+          .map(h => ({
+            icon: 'phone',
+            label: h,
+            href: h
+          }))
+        fillArrayIfEmpty(callCenters.contacts, { icon: 'phone' })
+        fillArrayIfEmpty(hotlines.contacts, { icon: 'phone' })
+      } catch (e) {
+        // silent error
+      }
+
+      return {
+        title: item.nama_kotkab,
+        groups: [callCenters, hotlines]
+      }
+    }
+  }
+}
+</script>

--- a/components/KenaliCovid/HospitalsAndCallCenters/Hospitals.vue
+++ b/components/KenaliCovid/HospitalsAndCallCenters/Hospitals.vue
@@ -1,0 +1,89 @@
+<template>
+  <WrapperItem v-bind="$data">
+    <template v-for="(item, i) in list">
+      <ContactCard
+        :key="i"
+        v-bind="item"
+        class="mt-6"
+      />
+    </template>
+  </WrapperItem>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import { toPhoneURL, toArray, fillArrayIfEmpty } from './utils'
+import WrapperItem from './WrapperItem'
+import { ContactCard } from '~/components/Base/ContactCard'
+
+export default {
+  components: {
+    WrapperItem,
+    ContactCard
+  },
+  data () {
+    return Object.freeze({
+      title: 'Daftar Rumah Sakit Rujukan',
+      body: `
+        Berikut ini adalah rumah sakit yang menjadi rujukan untuk pasien
+        Covid-19 dengan status Pasien dalam Pengawasan.
+      `,
+      buttonLink: '/contact'
+    })
+  },
+  computed: {
+    ...mapState('hospitals', {
+      isLoading: (state) => {
+        return !Array.isArray(state.items) ||
+          !state.items.length
+      }
+    }),
+    list () {
+      if (this.isLoading) {
+        return []
+      }
+      const { items } = this.$store.state.hospitals
+      return items.map(this.mapHospitalItem)
+    }
+  },
+  mounted () {
+    this.$store.dispatch('hospitals/getItems', { perPage: 3 })
+  },
+  methods: {
+    mapHospitalItem (item) {
+      const phones = {
+        name: 'Telepon',
+        contacts: []
+      }
+      const websites = {
+        name: 'Website',
+        contacts: []
+      }
+      try {
+        phones.contacts = toArray(item.phones)
+          .map(p => ({
+            icon: 'phone',
+            label: p,
+            href: toPhoneURL(p)
+          }))
+        websites.contacts = toArray(item.web)
+          .map(w => ({
+            icon: 'web',
+            label: w,
+            href: w
+          }))
+        fillArrayIfEmpty(phones.contacts, { icon: 'phone' })
+        fillArrayIfEmpty(websites.contacts, { icon: 'web' })
+      } catch (e) {
+        console.error(e)
+      }
+
+      return {
+        title: item.name,
+        body: `${item.address}, ${item.city}`,
+        groups: [phones, websites]
+      }
+    }
+  }
+}
+</script>

--- a/components/KenaliCovid/HospitalsAndCallCenters/Wrapper.vue
+++ b/components/KenaliCovid/HospitalsAndCallCenters/Wrapper.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="wrapper">
+    <CallCenters />
+    <Hospitals />
+  </div>
+</template>
+
+<script>
+import Hospitals from './Hospitals'
+import CallCenters from './CallCenters'
+
+export default {
+  components: {
+    Hospitals,
+    CallCenters
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.wrapper {
+  gap: 16px;
+  @apply grid grid-cols-1 grid-rows-1;
+
+  @screen lg {
+    gap: 32px;
+    @apply grid-cols-2 items-stretch;
+  }
+}
+</style>

--- a/components/KenaliCovid/HospitalsAndCallCenters/WrapperItem.vue
+++ b/components/KenaliCovid/HospitalsAndCallCenters/WrapperItem.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="wrapper-item">
+    <p class="wrapper-item__title">
+      {{ title }}
+    </p>
+    <p class="wrapper-item__body">
+      {{ body }}
+    </p>
+    <slot />
+    <i class="block flex-1" />
+    <ContentCardButton
+      class="wrapper-item__btn"
+      prompt="Lihat Selengkapnya"
+      button-type="outline"
+      :back-link="buttonLink"
+    />
+  </div>
+</template>
+
+<script>
+import ContentCardButton from '~/components/Base/ContentCard/ContentCardButton'
+export default {
+  components: {
+    ContentCardButton
+  },
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    body: {
+      type: String,
+      default: ''
+    },
+    buttonLink: {
+      type: String,
+      required: true
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.wrapper-item {
+  line-height: 1.618;
+
+  @apply w-full p-4
+  flex flex-col flex-no-wrap
+  rounded-lg
+  border border-solid border-gray-300;
+
+  &__title {
+    font-size: 20px;
+
+    @apply block m-0 mb-4 p-0
+    text-gray-900
+    font-bold font-serif;
+  }
+
+  &__body {
+    @apply block m-0 mb-6 p-0
+    text-base
+    text-gray-800
+    font-normal;
+  }
+
+  &__btn {
+    @apply mt-6;
+  }
+
+  @screen lg {
+    @apply px-8 py-6;
+
+    &__title {
+      @apply text-2xl;
+    }
+  }
+}
+</style>

--- a/components/KenaliCovid/HospitalsAndCallCenters/index.js
+++ b/components/KenaliCovid/HospitalsAndCallCenters/index.js
@@ -1,0 +1,6 @@
+import HospitalsAndCallCenters from './Wrapper'
+import Hospitals from './Hospitals'
+import CallCenters from './CallCenters'
+
+export { Hospitals, CallCenters, HospitalsAndCallCenters }
+export default HospitalsAndCallCenters

--- a/components/KenaliCovid/HospitalsAndCallCenters/utils.js
+++ b/components/KenaliCovid/HospitalsAndCallCenters/utils.js
@@ -1,0 +1,65 @@
+// TODO: might be wise to move this to "~/lib"
+
+/**
+ * @param   {any} value
+ * @returns {boolean}
+ */
+export function isPhoneURL (value) {
+  return typeof value === 'string' &&
+    value.startsWith('tel://')
+}
+
+/**
+ * @param   {string} value
+ * @returns {string | undefined} phone URL (tel://\<number>)
+ */
+export function toPhoneURL (value) {
+  if (isPhoneURL(value)) {
+    return value
+  }
+
+  const types = {
+    string: value,
+    number: `${value}`
+  }
+  const num = types[typeof value]
+  if (!num) {
+    console.warn(`Invalid phone url. Expected string or number, got ${num}`)
+    return
+  }
+  const trimmed = num.replace(/^\s+|\s+$|\s+(?=\s)/g, '')
+  return `tel://${encodeURIComponent(trimmed)}`
+}
+
+/**
+ * NOTES:
+ * falsy values will be transformed into empty array
+ * @param   {any} value
+ * @returns {Array<any>}
+ */
+export function toArray (value) {
+  // if falsy, e.g null, undefined, '', 0
+  if (!value) {
+    return []
+  }
+  // if not falsy, e.g 'abc', 123
+  // => ['abc'], [123]
+  if (!Array.isArray(value)) {
+    return [value]
+  }
+
+  // if an array, return itself
+  return value
+}
+
+/**
+ * @param   {Array} arr
+ * @param   {any} values
+ * @returns {Array} mutated array
+ */
+export function fillArrayIfEmpty (arr, ...values) {
+  if (Array.isArray(arr) && !arr.length) {
+    arr.push(...values)
+  }
+  return arr
+}

--- a/store/call-centers.js
+++ b/store/call-centers.js
@@ -1,4 +1,4 @@
-import { db } from '../lib/firebase'
+import { db } from '~/lib/firebase'
 
 export const state = () => ({
   items: null
@@ -13,9 +13,14 @@ export const mutations = {
 export const actions = {
   getItems ({ state, commit }, options) {
     if (!state.items || !state.items.length) {
-      return db.collection('call_centers')
+      let query = db.collection('call_centers')
         .orderBy('nama_kotkab', 'asc')
-        .get()
+
+      if (options.perPage) {
+        query = query.limit(options.perPage)
+      }
+      // TODO: move to "~/api"
+      return query.get()
         .then((docs) => {
           if (!docs.empty) {
             return docs.docs.map(doc => doc.data())

--- a/store/hospitals.js
+++ b/store/hospitals.js
@@ -13,7 +13,7 @@ export const mutations = {
 export const actions = {
   getItems ({ state, commit }, options) {
     if (!state.items || !state.items.length) {
-      return get()
+      return get(options)
         .then((items) => {
           commit('setItems', items)
           return state.items


### PR DESCRIPTION
### Task Description
[[Web S6] [Halaman Info Covid-19] Section Ketahui Risiko](https://trello.com/c/B2jmrC73/921-web-s6-halaman-info-covid-19-section-ketahui-risiko)

### Changes
- `call-centers` and `hospitals` vuex module
  - Ensure `options` argument is passed into Firebase query
- `ContactCardChip`
  - Add `disabled` state
- Create utilities to map `hospitals` and `call-centers` Firestore collection, in compliance with its corresponding component's props.
- Create views for `hospitals` and `call-centers` data

### Preview
![Screenshot from 2021-09-14 13 05 44](https://user-images.githubusercontent.com/20709202/133204462-3bb244d2-7d7f-4931-aa4f-7d29ca4454ca.png)
