### PR TITLE
Fix Action Card gap between image and title

### DIFF
--- a/components/Base/ActionCard/index.vue
+++ b/components/Base/ActionCard/index.vue
@@ -94,7 +94,7 @@ export default {
   }
 
   &__title {
-    @apply flex-1 mb-4
+    @apply flex-1 my-6 mb-4
     font-medium text-base text-left;
   }
 
@@ -138,6 +138,10 @@ export default {
       align-self: stretch;
 
       @apply col-span-2 flex-1 items-start;
+    }
+
+    &__title {
+      @apply my-0;
     }
 
     &__btn {


### PR DESCRIPTION
### Task Description
Ensure there is a `1.5rem` gap between `ActionCard` image and title on small viewport.

### Changes
- Add margin top to `ActionCard` title on small viewport.

### Preview
#### Before
![Screenshot from 2021-09-14 14 09 08](https://user-images.githubusercontent.com/20709202/133211641-02f984ee-1cd6-46d9-bfe5-082133fa543a.png)


#### After
![Screenshot from 2021-09-14 14 08 46](https://user-images.githubusercontent.com/20709202/133211691-eb951a7d-1d4e-4e47-b1a6-b62b99b6a2f6.png)

