### PR TITLE
delete v-on listener redundant with manual event listener

### DIFF
--- a/components/SelectInput/index.vue
+++ b/components/SelectInput/index.vue
@@ -10,7 +10,6 @@
         :name="name"
         :value="value"
         class="select-input__field placeholder-gray-600 focus:shadow-outline"
-        v-on="$listeners"
         :disabled="options.length === 0"
         @input="$emit('input', $event.target.value)"
         @change="$emit('input', $event.target.value)"


### PR DESCRIPTION
Preview:
- Event listener on mobile not working because redundant event listener set on input select

Related:
https://airtable.com/appEyAESlNjKaM4we/tbltoI1WyAmGtMSOA/viwYEJD8vBRO53Srp/rec4A23pZn0mBoaO0?blocks=hide