### PR TITLE
fix (TabLayout): fix tab content DOM painting, with regard to Carousel;

### DIFF
--- a/components/Base/TabLayout/TabLayout.vue
+++ b/components/Base/TabLayout/TabLayout.vue
@@ -170,7 +170,7 @@ export default {
 
   &__content-item {
     visibility: hidden;
-    @apply absolute top-0 left-0
+    @apply absolute inset-0
     pointer-events-none;
 
     &--visible {

--- a/components/Base/TabLayout/TabLayout.vue
+++ b/components/Base/TabLayout/TabLayout.vue
@@ -18,21 +18,21 @@
       :style="activeMarkerStyles"
     />
     <div class="tablayout__content-wrapper">
-      <template v-for="(tab, i) in tabs">
-        <keep-alive
-          :key="tab.name"
-          :max="1"
-        >
-          <TabContentItem v-if="i === mValue">
-            <template>
-              <slot
-                :name="`content.${tab.name}`"
-                v-bind="{ name: tab.name, index: i, tab }"
-              />
-            </template>
-          </TabContentItem>
-        </keep-alive>
-      </template>
+      <TabContentItem
+        v-for="(tab, i) in tabs"
+        :key="i"
+        :class="{
+          'tablayout__content-item': true,
+          'tablayout__content-item--visible': i === mValue
+        }"
+      >
+        <template>
+          <slot
+            :name="`content.${tab.name}`"
+            v-bind="{ name: tab.name, index: i, tab }"
+          />
+        </template>
+      </TabContentItem>
     </div>
   </div>
 </template>
@@ -165,7 +165,18 @@ export default {
   }
 
   &__content-wrapper {
-    @apply block;
+    @apply relative block;
+  }
+
+  &__content-item {
+    visibility: hidden;
+    @apply absolute top-0 left-0
+    pointer-events-none;
+
+    &--visible {
+      visibility: visible;
+      @apply relative pointer-events-auto;
+    }
   }
 }
 </style>

--- a/components/Base/TabLayout/TabLayout.vue
+++ b/components/Base/TabLayout/TabLayout.vue
@@ -18,18 +18,21 @@
       :style="activeMarkerStyles"
     />
     <div class="tablayout__content-wrapper">
-      <TabContentItem
-        v-for="(tab, i) in tabs"
-        v-show="i === mValue"
-        :key="i"
-      >
-        <template>
-          <slot
-            :name="`content.${tab.name}`"
-            v-bind="{ name: tab.name, index: i, tab }"
-          />
-        </template>
-      </TabContentItem>
+      <template v-for="(tab, i) in tabs">
+        <keep-alive
+          :key="tab.name"
+          :max="1"
+        >
+          <TabContentItem v-if="i === mValue">
+            <template>
+              <slot
+                :name="`content.${tab.name}`"
+                v-bind="{ name: tab.name, index: i, tab }"
+              />
+            </template>
+          </TabContentItem>
+        </keep-alive>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Issue
When a carousel lives within a tab layout, but is not set to be the default active tab content, then it would incorrectly compute its sizing.

https://user-images.githubusercontent.com/20709202/133739472-4d9ad7b9-41c9-48a1-addc-3a809d21f6bd.mp4

### Possible Cause
- `v-show`, a shorthand for `display: none`, is causing that carousel to incorrectly compute its sizing, due to having no information regarding its container width / height.

### Fixes
Use a different approach in toggling between visible tab content item. 
- Replace `v-show` directive with `visibility` CSS attribute

#### Preview

https://user-images.githubusercontent.com/20709202/133739560-2d7c9098-fe26-4dc3-87ab-0e6a8f5c318d.mp4

***
title: Memperbaiki komponen TabLayout
project: Pikobar Website
participants: @adrianpdm @ArifWicakSon 
