### PR TITLE
fix (ContentCard): use different title size for page heading and regular contents

### DIFF
--- a/components/Base/ContentCard/index.vue
+++ b/components/Base/ContentCard/index.vue
@@ -2,6 +2,7 @@
   <div
     :class="{
       'content-card': true,
+      'content-card--header-large': headerSize === 'large',
       'content-card--image-left': imagePosition === 'left',
       'content-card--image-right': imagePosition === 'right'
     }"
@@ -18,10 +19,11 @@
           <p class="content-card__title">
             {{ title }}
           </p>
-
-          <slot name="body" class="content-card__body text-black-500">
-            {{ body }}
-          </slot>
+          <div class="content-card__body text-gray-600">
+            <slot name="body">
+              {{ body }}
+            </slot>
+          </div>
           <slot v-if="prompt" name="button" v-bind="$props">
             <ContentCardButton
               v-bind="{ prompt, backLink, buttonType }"
@@ -41,6 +43,10 @@ export default {
     ContentCardButton
   },
   props: {
+    headerSize: {
+      type: String,
+      default: ''
+    },
     header: {
       type: String,
       default: ''
@@ -120,7 +126,8 @@ export default {
   }
 
   &__title {
-    @apply text-3xl font-semibold;
+    font-size: 20px;
+    @apply mb-4 font-semibold;
   }
 
   &__body {
@@ -131,9 +138,25 @@ export default {
     @apply w-full;
   }
 
+  &--header-large & {
+    &__title {
+      font-size: 24px;
+    }
+  }
+
   @screen lg {
     &__btn {
       @apply w-auto;
+    }
+
+    &__title {
+      font-size: 28px;
+    }
+
+    &--header-large & {
+      &__title {
+        font-size: 37px;
+      }
     }
 
     &--image-left & {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -129,6 +129,7 @@ export default {
       },
       listContent: [
         {
+          headerSize: 'large',
           title: 'Pusat Informasi & Koordinasi Covid-19 Jawa Barat',
           body: 'Media komunikasi dan informasi penanganan Covid-19 satu pintu di Jawa Barat. Hadirkan data dan visualisasi perkembangan kasus terkini Covid-19. Dilengkapi ragam layanan kesehatan digital pendukung kedaruratan pandemi.',
           image: '/img/icon-hero.svg',

--- a/pages/info/covid-19/index.vue
+++ b/pages/info/covid-19/index.vue
@@ -182,6 +182,7 @@ export default {
       },
       listContent: [
         {
+          headerSize: 'large',
           title: 'Informasi Covid-19',
           body: 'Covid-19 adalah penyakit yang disebabkan oleh Novel Coronavirus (2019-nCoV), jenis baru coronavirus yang pada manusia menyebabkan penyakit mulai flu biasa hingga penyakit yang serius.',
           image: '/img/icon-kenali-covid.svg',


### PR DESCRIPTION
### Task Description
For page heading, that is the topmost content on each revamped page, title size should be `37px` on desktop/tablet viewport and `28px` on mobile viewport.
Otherwise, use the default `28px` on desktop/tablet viewport and `20px` on mobile viewport.

### Changes
Adjust content card title styling, with regard to above criteria.

***
title: Perbaikan minor pada komponen dasar untuk tampilan konten
project: Pikobar Website
participants: @adrianpdm @maruf_harsono @adzharamrullah @ArifWicakSon @Ibwedagama @bangunbagustapa 