### PR TITLE
Fix page revamp layouting

### DIFF
--- a/components/AppFooter/index.vue
+++ b/components/AppFooter/index.vue
@@ -6,7 +6,7 @@
           <a href="/">
             <img class="h-10" src="/img/pikobar-logo-full.svg" alt="Pikobar Jabar Prov">
           </a>
-          <div class="grid grid-cols-2 md:grid-cols-1 items-center">
+          <div class="app-footer__store">
             <a :href="footerLink.gplayStore" target="_blank" rel="noopener noreferrer" class="flow-root mt-4 md:mt-10">
               <img src="/img/gplay-app-store-badge.svg" alt="Google Play Badge">
             </a>
@@ -152,6 +152,14 @@ export default {
 
     &-text {
       @apply pb-4 text-base text-white text-center;
+    }
+  }
+
+  &__store {
+    @apply flex flex-row gap-2 items-center;
+
+    @screen md {
+      @apply grid grid-cols-1;
     }
   }
 }

--- a/pages/faq/index.vue
+++ b/pages/faq/index.vue
@@ -21,6 +21,7 @@
           <div>
             <div class="rounded border">
               <CategoryTabFAQ
+                v-show="query.search === ''"
                 :data="data"
                 :selected="query.category"
                 :tab-selected.sync="query.category"

--- a/pages/faq/index.vue
+++ b/pages/faq/index.vue
@@ -19,9 +19,11 @@
       <div>
         <div class="lg:grid lg:grid-cols-4 lg:gap-8">
           <div>
-            <div class="rounded border">
+            <div
+              class="rounded border"
+              :class="{ 'hidden lg:block': query.search }"
+            >
               <CategoryTabFAQ
-                v-show="query.search === ''"
                 :data="data"
                 :selected="query.category"
                 :tab-selected.sync="query.category"

--- a/pages/faq/index.vue
+++ b/pages/faq/index.vue
@@ -11,7 +11,7 @@
       </div>
       <div class="py-10">
         <StringSearchQuery
-          :placeholder="'Cari pertanyaan di sini.'"
+          :placeholder="'Cari informasi di sini...'"
           :value="query.search"
           @search="onSearchStringChanged"
         />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,7 +12,7 @@
         <template #button="props">
           <ContentCardButton
             v-bind="props"
-            class="mt-6"
+            class="mt-6 w-full lg:w-auto"
           />
         </template>
       </ContentCard>
@@ -30,7 +30,10 @@
         @loading="onSectionLoad('eventStatistics', $event)"
       />
       <div class="mt-6 md:mt-10 flex flex-row justify-center">
-        <ContentCardButton v-bind="button.eventStatistics" />
+        <ContentCardButton
+          v-bind="button.eventStatistics"
+          class="w-full lg:w-auto"
+        />
       </div>
     </Section>
     <Section class="bg-white">


### PR DESCRIPTION
### Changes
1. fix mobile view width button `selengkapnya` on homepage
2. change faq search input placeholder
3. hide faq category section when search input filled
4. fix playstore and appstore footer icon layouting in mobile view
### Task
https://trello.com/c/0wKPymFu/958-regression-test-web
### Evidence
title: Fix page revamp layouting
project: Pikobar Website
participants: @naufalihsank @maulanayuseph @maruf12 @adzharamrullah @bangunbagustapa @yoslie 