### PR TITLE
Feat: Infographics and Documents search

### DIFF
--- a/components/TabLayout/index.vue
+++ b/components/TabLayout/index.vue
@@ -15,6 +15,12 @@
       >
         <a :class="['text-lg', tab.id === mActiveTabId && 'font-bold text-brand-green']">
           {{ tab.title }}
+          <span
+            v-show="showCounts"
+            :class="tab.id === mActiveTabId ? 'count--active' : 'count'"
+          >
+            {{ counts(tab) }}
+          </span>
         </a>
       </li>
     </ul>
@@ -33,6 +39,10 @@ export default {
       default: null
     },
     fixed: {
+      type: Boolean,
+      default: false
+    },
+    showCounts: {
       type: Boolean,
       default: false
     }
@@ -56,11 +66,23 @@ export default {
         this.mActiveTabId = newTabId
         this.$emit('change', newTabId)
       }
+    },
+    counts (tab) {
+      return tab.counts > 99 ? '99+' : tab.counts
     }
   }
 }
 </script>
 
-<style>
+<style lang="scss" scoped>
+.count {
+  @apply text-xs rounded-lg ml-3 p-1
+  bg-gray-500 text-white;
 
+  &--active {
+    @apply text-xs rounded-lg
+    border-brand-green text-white
+    bg-brand-green ml-3 p-1;
+  }
+}
 </style>

--- a/components/_pages/documents/DocumentList.vue
+++ b/components/_pages/documents/DocumentList.vue
@@ -34,6 +34,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import DocumentItem from './DocumentItem.vue'
 import DocumentSkeleton from './DocumentSkeleton.vue'
 export default {
@@ -52,8 +53,11 @@ export default {
     }
   },
   computed: {
+    ...mapState('documents', [
+      'isFiltered'
+    ]),
     showLoadMore () {
-      return !this.loading && this.items?.length
+      return !this.loading && this.items?.length && !this.isFiltered
     },
     showEmptyFig () {
       return !this.loading && !this.items?.length
@@ -69,7 +73,7 @@ export default {
 
 <style lang="scss" scoped>
 .document-list {
-  @apply flex flex-col gap-4;
+  @apply flex flex-col gap-4 pb-5;
 
   &__container {
     @apply flex justify-center items-center;

--- a/components/_pages/documents/DocumentList.vue
+++ b/components/_pages/documents/DocumentList.vue
@@ -1,24 +1,34 @@
 <template>
   <div class="document-list">
-    <div v-if="loading && !items.length">
+    <DocumentItem
+      v-for="doc in items"
+      :key="doc.id"
+      :doc="doc"
+    />
+    <div v-if="loading">
       <DocumentSkeleton
         v-for="i in 3"
         :key="i"
         class="mb-3"
       />
     </div>
-    <DocumentItem
-      v-for="doc in items"
-      :key="doc.id"
-      :doc="doc"
-    />
-    <div v-if="!loading" class="document-list__container">
+    <div v-if="showLoadMore" class="document-list__container">
       <button
         class="document-list__button"
         @click="onLoadMore"
       >
         Load More
       </button>
+    </div>
+    <div
+      v-if="showEmptyFig"
+      class="flex justify-center"
+    >
+      <img
+        src="~/static/img/icon-empty-state.svg"
+        alt="img-faq-empty"
+        class="mb-5"
+      >
     </div>
   </div>
 </template>
@@ -27,6 +37,10 @@
 import DocumentItem from './DocumentItem.vue'
 import DocumentSkeleton from './DocumentSkeleton.vue'
 export default {
+  components: {
+    DocumentItem,
+    DocumentSkeleton
+  },
   props: {
     items: {
       type: Array,
@@ -37,9 +51,13 @@ export default {
       default: false
     }
   },
-  components: {
-    DocumentItem,
-    DocumentSkeleton
+  computed: {
+    showLoadMore () {
+      return !this.loading && this.items?.length
+    },
+    showEmptyFig () {
+      return !this.loading && !this.items?.length
+    }
   },
   methods: {
     onLoadMore () {

--- a/pages/info.vue
+++ b/pages/info.vue
@@ -104,7 +104,6 @@ export default {
           return `${str}`.toLowerCase().includes(this.query.search.toLowerCase())
         })
       })
-      console.log(array)
       return array
     },
     async onSearchStringChanged (str) {

--- a/pages/info/documents/index.vue
+++ b/pages/info/documents/index.vue
@@ -30,7 +30,7 @@ export default {
   },
   data () {
     return {
-      isPending: true,
+      isPending: false,
       columns: [
         {
           prop: 'published_at',
@@ -45,7 +45,8 @@ export default {
   },
   computed: {
     ...mapState('documents', {
-      documents: 'items'
+      documents: 'items',
+      isFiltered: 'isFiltered'
     }),
     shareableDocumentsColumns () {
       return [
@@ -72,14 +73,16 @@ export default {
     }
   },
   mounted () {
-    this.isPending = true
-    this.getItems()
-      .finally(() => {
-        if (process.browser) {
-          analytics.logEvent('documents_list_view')
-        }
-        this.isPending = false
-      })
+    if (!this.isFiltered) {
+      this.isPending = true
+      this.getItems()
+        .finally(() => {
+          this.isPending = false
+        })
+    }
+    if (process.browser) {
+      analytics.logEvent('documents_list_view')
+    }
   },
   methods: {
     ...mapActions('documents', {
@@ -89,7 +92,11 @@ export default {
       return _get(row, column.prop)
     },
     onLoadMore () {
+      this.isPending = true
       this.getItems({ fresh: true })
+        .finally(() => {
+          this.isPending = false
+        })
     }
   },
   head () {

--- a/pages/info/infographics/index.vue
+++ b/pages/info/infographics/index.vue
@@ -6,15 +6,6 @@
       </p>
     </h2>
     <br>
-    <div
-      v-if="showLoader"
-      class="infographic__skeleton"
-    >
-      <InfographicSkeleton
-        v-for="i in 4"
-        :key="i"
-      />
-    </div>
     <div v-show="isImageLoaded" class="infographic__list">
       <figure
         v-for="(item, index) in infographics"
@@ -38,9 +29,18 @@
         </caption>
       </figure>
     </div>
+    <div
+      v-if="showLoader"
+      class="infographic__skeleton"
+    >
+      <InfographicSkeleton
+        v-for="i in 4"
+        :key="i"
+      />
+    </div>
     <br>
     <div
-      v-if="!isPending && isImageLoaded"
+      v-if="showLoadMore"
       class="flex justify-center pb-6"
     >
       <button
@@ -49,6 +49,16 @@
       >
         Load More
       </button>
+    </div>
+    <div
+      v-if="showEmptyFig"
+      class="flex justify-center"
+    >
+      <img
+        src="~/static/img/icon-empty-state.svg"
+        alt="img-faq-empty"
+        class="mb-5"
+      >
     </div>
   </div>
 </template>
@@ -69,27 +79,37 @@ export default {
         faDownload,
         faShare
       },
-      isPending: true,
+      isPending: false,
       isImageLoaded: false
     }
   },
   computed: {
     ...mapState('infographics', {
-      infographics: 'items'
+      infographics: 'items',
+      isFiltered: 'isFiltered'
     }),
     showLoader () {
-      return this.isPending || !this.infographics.length || !this.isImageLoaded
+      return this.isPending || (!this.isImageLoaded && this.infographics.length)
+    },
+    showLoadMore () {
+      return !this.isPending && this.isImageLoaded && this.infographics.length && !this.isFiltered
+    },
+    showEmptyFig () {
+      return !this.infographics.length && !this.showLoader
     }
   },
   mounted () {
-    this.isPending = true
-    this.getItems({ perPage: 12 })
-      .finally(() => {
-        if (process.browser) {
-          analytics.logEvent('infographic_list_view')
-        }
-        this.isPending = false
-      })
+    if (!this.isFiltered) {
+      console.log('masuk')
+      this.isPending = true
+      this.getItems({ perPage: 12 })
+        .finally(() => {
+          this.isPending = false
+        })
+    }
+    if (process.browser) {
+      analytics.logEvent('infographic_list_view')
+    }
   },
   methods: {
     ...mapActions('infographics', {

--- a/pages/info/infographics/index.vue
+++ b/pages/info/infographics/index.vue
@@ -100,7 +100,6 @@ export default {
   },
   mounted () {
     if (!this.isFiltered) {
-      console.log('masuk')
       this.isPending = true
       this.getItems({ perPage: 12 })
         .finally(() => {

--- a/store/documents.js
+++ b/store/documents.js
@@ -4,7 +4,8 @@ import { get, getById, ORDER_INDEX, ORDER_TYPE } from '~/api/documents'
 
 export const state = () => ({
   items: [],
-  lastSnapshot: null
+  lastSnapshot: null,
+  isFiltered: false
 })
 
 export const getters = {
@@ -33,24 +34,31 @@ export const mutations = {
   },
   setLastSnapshot (state, lastSnapshot) {
     state.lastSnapshot = lastSnapshot
+  },
+  setIsFiltered (state, data) {
+    state.isFiltered = data
   }
 }
 
 export const actions = {
-  getItems ({ state, commit }, options = { fresh: false }) {
+  getItems ({ state, commit }, options = { fresh: false, isFiltered: false }) {
     if (!state.items || !state.items.length || options.fresh) {
       return get({
         ...options,
         lastSnapshot: state.lastSnapshot
       })
         .then(({ data, lastSnapshot }) => {
-          if (process.client || process.browser) {
-            commit('appendItems', data)
-            commit('setLastSnapshot', lastSnapshot)
+          if (!options.isFiltered) {
+            if (process.client || process.browser) {
+              commit('appendItems', data)
+              commit('setLastSnapshot', lastSnapshot)
+            } else {
+              commit('setItems', data)
+            }
+            return state.items
           } else {
-            commit('setItems', data)
+            return data
           }
-          return state.items
         })
     }
     return state.items
@@ -65,5 +73,11 @@ export const actions = {
         commit('setItems', [...state.items, item])
         return getters.itemsMap[id]
       })
+  },
+  setItems ({ commit }, items) {
+    commit('setItems', items)
+  },
+  setIsFiltered ({ commit }, data) {
+    commit('setIsFiltered', data)
   }
 }

--- a/store/infographics.js
+++ b/store/infographics.js
@@ -5,7 +5,8 @@ import { get, getById, ORDER_INDEX, ORDER_TYPE } from '~/api/infographic'
 
 export const state = () => ({
   items: [],
-  lastSnapshot: null
+  lastSnapshot: null,
+  isFiltered: false
 })
 
 export const getters = {
@@ -34,24 +35,31 @@ export const mutations = {
   },
   setLastSnapshot (state, lastSnapshot) {
     state.lastSnapshot = lastSnapshot
+  },
+  setIsFiltered (state, data) {
+    state.isFiltered = data
   }
 }
 
 export const actions = {
-  getItems ({ state, commit }, options = { perPage: 6, fresh: false }) {
+  getItems ({ state, commit }, options = { perPage: 6, fresh: false, isFiltered: false }) {
     if (!state.items || !state.items.length || options.fresh) {
       return get({
         ...options,
         lastSnapshot: state.lastSnapshot
       })
         .then(({ data, lastSnapshot }) => {
-          if (process.client || process.browser) {
-            commit('appendItems', data)
-            commit('setLastSnapshot', lastSnapshot)
+          if (!options.isFiltered) {
+            if (process.client || process.browser) {
+              commit('appendItems', data)
+              commit('setLastSnapshot', lastSnapshot)
+            } else {
+              commit('setItems', data)
+            }
+            return state.items
           } else {
-            commit('setItems', data)
+            return data
           }
-          return state.items
         })
     }
     return state.items
@@ -66,5 +74,11 @@ export const actions = {
         commit('setItems', [...state.items, item])
         return getters.itemsMap[id]
       })
+  },
+  setItems ({ commit }, items) {
+    commit('setItems', items)
+  },
+  setIsFiltered ({ commit }, data) {
+    commit('setIsFiltered', data)
   }
 }


### PR DESCRIPTION
### Changes
1. create search function and component for `info/infographics` and `info/documents`
2. display result count label in `info/infographics` and `info/documents` tabs
### Task
[[Web S10] [Informasi > Info Praktikal] Badge pada tab Info Praktikal & Dokumen ketika menampilkan hasil pencarian](https://trello.com/c/fhhJ5DRu/977-web-s10-informasi-info-praktikal-badge-pada-tab-info-praktikal-dokumen-ketika-menampilkan-hasil-pencarian)
### Preview
![Infografis - Pikobar  Pusat Informasi dan Koordinasi COVID-19 Jawa Barat  — Mozilla Firefox 2021-12-15 10-27-28](https://user-images.githubusercontent.com/56071566/146118415-6958cfbf-2f0b-4d50-b339-b36604ad62a3.gif)
### Evidence
title: Infographics and Documents search
project: Pikobar Website
participants: @naufalihsank @maulanayuseph @adzharamrullah @Ibwedagama @bangunbagustapa @yoslie 