### PR TITLE
Hotfix: Remove Periksa Mandiri from footer

### DIFF
--- a/components/AppFooter/index.vue
+++ b/components/AppFooter/index.vue
@@ -77,10 +77,6 @@ export default {
     return {
       listMenuFooter: [
         {
-          title: 'Periksa Mandiri',
-          link: 'https://covid19.prixa.ai/partner/80b47a20-1353-49e9-af91-a0a5995ca89f/app/52b7d983-3e5d-49cc-9c99-508dc779aad3'
-        },
-        {
           title: 'Forum Pikobar',
           link: 'https://forum.pikobar.jabarprov.go.id/'
         },

--- a/pages/temp/disclaimer/rdt.vue
+++ b/pages/temp/disclaimer/rdt.vue
@@ -15,25 +15,21 @@
     </header>
     <section class="max-w-xl mx-auto my-8 md:p-8 md:bg-white md:rounded-lg md:shadow-xl md:border md:border-solid md:border-gray-300">
       <h4 class="text-xl text-center">
-        <strong>Perhatian</strong>
+        <strong>Pemberitahuan</strong>
       </h4>
       <br>
       <p>
-        Pendaftaran Peserta TES MASIF COVID-19 bersifat terbatas dan
-        hanya diprioritaskan bagi masyarakat dengan profesi interaksi tinggi dengan publik,
-        rawan terinfeksi dan/atau yang memiliki gejala COVID-19.
+        Fitur Periksa Mandiri dan Pendaftaran Tes Masif Covid-19 akan dihilangkan pada Website dan Aplikasi Pikobar pada 2022 mendatang. Namun, Anda masih bisa melakukan pengetesan dan pendaftaran tes Covid-19 melalui fasilitas pelayanan kesehatan terdekat.
         <br><br>
-        Peserta yang telah <b>melalui tahap diagnosa dari fitur Periksa Mandiri</b>
-        dan telah mendaftarkan diri, akan diverifikasi dan divalidasi oleh Dinas Kesehatan Kabupaten/Kota dan Dinas Kesehatan Provinsi.
-        Hanya peserta yang disetujuilah yang dapat mengikuti tes ini.
+        Terima kasih.
       </p>
       <br>
       <p class="text-center my-4">
         <a
-          class="appearance-none px-4 py-2 rounded-lg text-white bg-brand-blue"
-          :href="backlink"
+          class="appearance-none px-4 py-2 rounded-lg text-white bg-brand-blue cursor-pointer"
+          @click="$router.back()"
         >
-          Mengerti
+          Kembali
         </a>
       </p>
     </section>


### PR DESCRIPTION
### Changes
1. Remove `Periksa Mandiri` from footer
2. Change tes masif disclaimer redaction
### Evidence
title: Remove Periksa Mandiri from footer
project: Pikobar Website
participants: @naufalihsank @maulanayuseph @adzharamrullah @bangunbagustapa @yoslie 