### PR TITLE
Hotfix: Items filtering

### DIFF
--- a/api/news.js
+++ b/api/news.js
@@ -12,6 +12,7 @@ export function get (options = { perPage: 3, tag: null }) {
   if (typeof options.tag === 'string' && options.tag.length) {
     query = query.where('tag', '==', options.tag)
   }
+
   return query
     .get()
     .then((docs) => {
@@ -33,11 +34,15 @@ export function get (options = { perPage: 3, tag: null }) {
     })
 }
 
-export function getArticleNational (options = { perPage: 3 }) {
-  const query = db.collection('articles_national')
+export function getArticleNational (options = { perPage: 3, tag: null }) {
+  let query = db.collection('articles_national')
     .orderBy(ORDER_INDEX, 'desc')
     .limit(options.perPage)
 
+  if (typeof options.tag === 'string' && options.tag.length) {
+    query = query.where('tag', '==', options.tag)
+  }
+
   return query
     .get()
     .then((docs) => {
@@ -59,11 +64,15 @@ export function getArticleNational (options = { perPage: 3 }) {
     })
 }
 
-export function getArticleWorld (options = { perPage: 3 }) {
-  const query = db
+export function getArticleWorld (options = { perPage: 3, tag: null }) {
+  let query = db
     .collection('articles_world')
     .orderBy(ORDER_INDEX, 'desc')
     .limit(options.perPage)
+
+  if (typeof options.tag === 'string' && options.tag.length) {
+    query = query.where('tag', '==', options.tag)
+  }
 
   return query
     .get()

--- a/components/Homepage/RecentNewsCarousel/index.vue
+++ b/components/Homepage/RecentNewsCarousel/index.vue
@@ -24,7 +24,16 @@ export default {
   computed: {
     ...mapState('news', {
       news: (state) => {
-        const items = state.items || []
+        // get articles from 3 collection
+        const provinceNews = state.items || []
+        const nationalNews = state.item_articles_national || []
+        const worldNews = state.item_articles_world || []
+
+        // filtering 4 most recent news from 3 collection
+        let items = [...provinceNews, ...nationalNews, ...worldNews]
+        items.sort((a, b) => (a.published_at < b.published_at) ? 1 : -1)
+        items = items.slice(0, 4)
+
         return items.map(item => ({
           ...item,
           thumbnail: item.image,
@@ -58,6 +67,14 @@ export default {
     )
     this.$store.dispatch('news/getLastUpdate')
     this.$store.dispatch('news/getItems', {
+      perPage: 4,
+      tag: this.tag
+    })
+    this.$store.dispatch('news/getArticleNationals', {
+      perPage: 4,
+      tag: this.tag
+    })
+    this.$store.dispatch('news/getArticleWorlds', {
       perPage: 4,
       tag: this.tag
     })

--- a/components/Homepage/RecentNewsCarousel/index.vue
+++ b/components/Homepage/RecentNewsCarousel/index.vue
@@ -15,6 +15,12 @@ export default {
   components: {
     NewsCarousel
   },
+  props: {
+    tag: {
+      type: String,
+      default: null
+    }
+  },
   computed: {
     ...mapState('news', {
       news: (state) => {
@@ -53,7 +59,7 @@ export default {
     this.$store.dispatch('news/getLastUpdate')
     this.$store.dispatch('news/getItems', {
       perPage: 4,
-      tag: 'vaksin'
+      tag: this.tag
     })
   }
 }

--- a/components/Homepage/RecentNewsCarousel/index.vue
+++ b/components/Homepage/RecentNewsCarousel/index.vue
@@ -52,7 +52,8 @@ export default {
     )
     this.$store.dispatch('news/getLastUpdate')
     this.$store.dispatch('news/getItems', {
-      perPage: 4
+      perPage: 4,
+      tag: 'vaksin'
     })
   }
 }

--- a/components/Vaccine/NewsTabLayout.vue
+++ b/components/Vaccine/NewsTabLayout.vue
@@ -3,10 +3,10 @@
   <TabLayout v-model="tabLayoutModel" :tabs="tabs">
     <template #content.recent>
       <p class="text-gray-900">
-        Info yang memuat berita seputar vaksinasi di Jawa Barat.
+        Info yang memuat berita seputar vaksinasi di Jawa Barat, nasional, dan dunia.
       </p>
       <div class="mt-10">
-        <RecentNewsCarousel key="recentNewsCarousel" tag="vaksin" />
+        <RecentNewsCarousel key="recentNewsCarousel" :tag="'vaksin'" />
       </div>
     </template>
     <template #content.antiHoax>

--- a/components/Vaccine/NewsTabLayout.vue
+++ b/components/Vaccine/NewsTabLayout.vue
@@ -6,7 +6,7 @@
         Info yang memuat berita seputar vaksinasi di Jawa Barat.
       </p>
       <div class="mt-10">
-        <RecentNewsCarousel key="recentNewsCarousel" />
+        <RecentNewsCarousel key="recentNewsCarousel" tag="vaksin" />
       </div>
     </template>
     <template #content.antiHoax>

--- a/pages/faq/index.vue
+++ b/pages/faq/index.vue
@@ -186,7 +186,7 @@ export default {
       this.filteredItems = this.items.filter((faq) => {
         if (query?.category) {
           return [faq.category_id].some((str) => {
-            return `${str}`.includes(query.category)
+            return str === query.category
           })
         }
 


### PR DESCRIPTION
### Changes
Fix filtering on `faq` and `vaccine` pages
### Task
1. [[Web S12][FAQ] FAQ dgn category Vaksin masuk ke dalam tab Covid-19](https://trello.com/c/XrLccXUY/1004-web-s12faq-faq-dgn-category-vaksin-masuk-ke-dalam-tab-covid-19)
2. [[Web S12][Vaksinasi] Berita yg tidak ber tag "vaksin" masuk ke dalam tab Berita Vaksinasi](https://trello.com/c/tuFlUWD2/1003-web-s12vaksinasi-berita-yg-tidak-ber-tag-vaksin-masuk-ke-dalam-tab-berita-vaksinasi)
### Evidence
title: Hotfix items filtering
project: Pikobar Website
participants: @naufalihsank @maulanayuseph @maruf12 @adzharamrullah @Ibwedagama @bangunbagustapa @yoslie 