### PR TITLE
Hotfix: fix unclickable news

### DIFF
--- a/api/news.js
+++ b/api/news.js
@@ -106,7 +106,43 @@ export function getById (id) {
           ...data,
           id: doc.id,
           published_at: data.published_at.toDate(),
-          route: slugifyArticleRoute(doc.id, data.title)
+          url: slugifyArticleRoute(doc.id, data.title)
+        }
+      }
+      return null
+    })
+}
+
+export function getByIdNational (id) {
+  return db.collection('articles_national')
+    .doc(id)
+    .get()
+    .then((doc) => {
+      if (doc.exists) {
+        const data = doc.data()
+        return {
+          ...data,
+          id: doc.id,
+          published_at: data.published_at.toDate(),
+          url: slugifyArticleRoute(doc.id, data.title)
+        }
+      }
+      return null
+    })
+}
+
+export function getByIdWorld (id) {
+  return db.collection('articles_world')
+    .doc(id)
+    .get()
+    .then((doc) => {
+      if (doc.exists) {
+        const data = doc.data()
+        return {
+          ...data,
+          id: doc.id,
+          published_at: data.published_at.toDate(),
+          url: slugifyArticleRoute(doc.id, data.title)
         }
       }
       return null

--- a/components/AppDrawer/index.vue
+++ b/components/AppDrawer/index.vue
@@ -93,7 +93,7 @@ export default {
         },
         { to: '/vaccine', label: 'Vaksinasi', icon: this.icon.faSyringe },
         { to: '/isoman', label: 'Isoman', icon: this.icon.faHotel },
-        { to: '/oxygen', label: 'Cari Oksgien', icon: this.icon.faLungs },
+        { to: '/oxygen', label: 'Cari Oksigen', icon: this.icon.faLungs },
         { to: '/donate/logistic', label: 'Donasi', icon: this.icon.faBoxOpen },
         {
           to: '#',

--- a/components/Homepage/BannerCarousel/index.vue
+++ b/components/Homepage/BannerCarousel/index.vue
@@ -35,7 +35,7 @@ export default {
   },
   methods: {
     onClickSlide (slide) {
-      const { route } = slide
+      const route = slide.route || slide.action_url
       if (typeof route !== 'string' || !route.length) {
         return
       }

--- a/components/Homepage/RecentNewsCarousel/index.vue
+++ b/components/Homepage/RecentNewsCarousel/index.vue
@@ -39,7 +39,7 @@ export default {
           thumbnail: item.image,
           date: item.published_at,
           source: item.news_channel,
-          url: item.route
+          url: item.url
         }))
       },
       /**

--- a/components/KenaliCovid/HospitalsAndCallCenters/CallCenters.vue
+++ b/components/KenaliCovid/HospitalsAndCallCenters/CallCenters.vue
@@ -61,7 +61,7 @@ export default {
         .map(h => ({
           icon: 'phone',
           label: h,
-          href: h
+          href: toPhoneURL(h)
         }))
 
       return {

--- a/components/KenaliCovid/HospitalsAndCallCenters/CallCenters.vue
+++ b/components/KenaliCovid/HospitalsAndCallCenters/CallCenters.vue
@@ -52,16 +52,16 @@ export default {
   methods: {
     mapCallCenteritem (item) {
       const callCenters = toArray(item.call_center)
-        .map(cc => ({
+        .map(callCenter => ({
           icon: 'phone',
-          label: cc,
-          href: toPhoneURL(cc)
+          label: callCenter,
+          href: toPhoneURL(callCenter)
         }))
       const hotlines = toArray(item.hotline)
-        .map(h => ({
+        .map(hotline => ({
           icon: 'phone',
-          label: h,
-          href: toPhoneURL(h)
+          label: hotline,
+          href: toPhoneURL(hotline)
         }))
 
       return {

--- a/pages/articles/_slug.vue
+++ b/pages/articles/_slug.vue
@@ -114,7 +114,7 @@ export default {
     formatDateTimeShort,
     fetchItem () {
       this.isLoading = true
-      return this.$store.dispatch('news/getItemById', this.itemId)
+      return this.$store.dispatch('news/getItemByIdFromAllCollection', this.itemId)
         .then(() => {
           if (process.client || process.browser) {
             analytics.logEvent('article_detail_view', { id: this.itemId })


### PR DESCRIPTION
### Changes
1. Fix unclickable news in `/vaccine`
2. Fix redirect phone number in `/info/covid-19`
3. Fix unclickable banner in Landing Page
### Task
1. [[Web S12][Vaksinasi] Berita yg tidak ber tag "vaksin" masuk ke dalam tab Berita Vaksinasi](https://trello.com/c/tuFlUWD2/1003-web-s12vaksinasi-berita-yg-tidak-ber-tag-vaksin-masuk-ke-dalam-tab-berita-vaksinasi)
2. [[Web S12][Landing Page] Beberapa link tidak bisa diklik](https://trello.com/c/xVmBhvkH/1015-web-s12landing-page-beberapa-link-tidak-bisa-diklik)
3. [[Web S12][Info Covid] Link no Telp di Call Center tidak bisa diklik](https://trello.com/c/SFOhjqtA/1014-web-s12info-covid-link-no-telp-di-call-center-tidak-bisa-diklik)
### Evidence
title: Fix unclickable news
project: Pikobar Website
participants: @naufalihsank @maulanayuseph @adzharamrullah @Ibwedagama @bangunbagustapa @yoslie 