### PR TITLE
Fix parse int to handle area id selected

### DIFF
--- a/components/_pages/index/VitaminRequest/ConfirmationDetail.vue
+++ b/components/_pages/index/VitaminRequest/ConfirmationDetail.vue
@@ -78,7 +78,7 @@ export default {
       if (!array) {
         return null
       }
-      const result = array.find(area => area.id === parseInt(param)) || { name: '-' }
+      const result = array.find(area => parseInt(area.id) === parseInt(param)) || { name: '-' }
       return result.name
     },
     displayImage (item) {


### PR DESCRIPTION
**Description**
Mutation `id` district from `int` to `string` must be customized

**Changes**
As described in PR title

**Evidence**
title: Fix parse int to handle area id selected
project: Pikobar Website
participants: @maulanayuseph @adzharamrullah @naufalihsank @yoslie 