### PR TITLE
Fix detail anti-hoax article which is doesn't appear

### DIFF
--- a/components/Base/NewsCarousel/NewsCarouselItem.vue
+++ b/components/Base/NewsCarousel/NewsCarouselItem.vue
@@ -3,6 +3,7 @@
     <img
       class="news-carousel-item__img"
       :src="thumbnail"
+      :alt="url"
       @click="goToUrl"
     >
     <div class="news-carousel-item__body">
@@ -52,6 +53,10 @@ export default {
     url: {
       type: String,
       default: null
+    },
+    backlink: {
+      type: String,
+      default: null
     }
   },
   computed: {
@@ -63,12 +68,14 @@ export default {
   },
   methods: {
     goToUrl () {
-      const { url } = this
+      const { url, source, backlink } = this
       if (typeof url !== 'string' || !url.length) {
         return
       }
       if (url.startsWith('http')) {
         return window.open(url, '_blank')
+      } else if (source === 'Anti Hoax') {
+        return window.open(backlink, '_blank')
       } else {
         return this.$router.push(url)
       }

--- a/pages/articles/index.vue
+++ b/pages/articles/index.vue
@@ -6,7 +6,7 @@
         Berita Terkini
       </h2>
       <h4 class="subtitle">
-        Berita seputar Covid-19 mulai dari berita lokal hingga mancanegara.
+        Berita seputar Covid-19 mulai dari rilis pers, berita lokal, nasional hingga mancanegara.
       </h4>
     </div>
     <div class="py-10">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -146,22 +146,22 @@ export default {
           prompt: 'Selengkapnya'
         },
         {
-          header: 'Kenali Covid-19',
-          title: 'Kenali Informasi Seputar Covid-19',
-          body: 'Ketahui penyakit yang disebabkan oleh Novel Coronavirus (2019-nCoV), gejala, serta penularan Covid-19. Dapatkan informasi soal tindakan yang harus dilakukan jika tertular Covid-19, juga tren penanganan pandemi di Jawa Barat.',
-          image: '/img/icon-kenali-covid.svg',
-          imagePosition: 'right',
-          backLink: '/info/covid-19',
-          buttonType: 'outline',
-          prompt: 'Selanjutnya'
-        },
-        {
           header: 'Penanganan Covid-19',
           title: 'Apa itu Testing, Tracing, Treatment (3T)?',
           body: 'Testing, tracing, dan treatment atau melakukan pengetesan, penelusuran kontak, dan perawatan terhadap pasien Covid-19 dapat bantu petakan penularan sedini mungkin, sehingga peluang penyebaran Covid-19 bisa diantisipasi. Ketahui lebih jauh perkembangan upaya 3T di Jawa Barat selengkapnya.',
           image: '/img/icon-isoman.svg',
           imagePosition: 'left',
           backLink: '/3t',
+          buttonType: 'outline',
+          prompt: 'Selanjutnya'
+        },
+        {
+          header: 'Kenali Covid-19',
+          title: 'Kenali Informasi Seputar Covid-19',
+          body: 'Ketahui penyakit yang disebabkan oleh Novel Coronavirus (2019-nCoV), gejala, serta penularan Covid-19. Dapatkan informasi soal tindakan yang harus dilakukan jika tertular Covid-19, juga tren penanganan pandemi di Jawa Barat.',
+          image: '/img/icon-kenali-covid.svg',
+          imagePosition: 'right',
+          backLink: '/info/covid-19',
           buttonType: 'outline',
           prompt: 'Selanjutnya'
         },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -146,6 +146,16 @@ export default {
           prompt: 'Selengkapnya'
         },
         {
+          header: 'Informasi Vaksin',
+          title: 'Pelajari Informasi soal Vaksinasi Covid-19',
+          body: 'Ketahui lebih jauh program Vaksinasi Covid-19 sebagai upaya mencapai herd immunity sekaligus menurunkan angka penyakit dan kematian akibat Covid-19. Baca selengkapnya untuk mengetahui informasi lebih lanjut tentang Vaksinasi Covid-19 di Jawa Barat.',
+          image: '/img/icon-inject-vaccine.svg',
+          imagePosition: 'right',
+          backLink: '/vaccine',
+          buttonType: 'outline',
+          prompt: 'Selanjutnya'
+        },
+        {
           header: 'Penanganan Covid-19',
           title: 'Apa itu Testing, Tracing, Treatment (3T)?',
           body: 'Testing, tracing, dan treatment atau melakukan pengetesan, penelusuran kontak, dan perawatan terhadap pasien Covid-19 dapat bantu petakan penularan sedini mungkin, sehingga peluang penyebaran Covid-19 bisa diantisipasi. Ketahui lebih jauh perkembangan upaya 3T di Jawa Barat selengkapnya.',
@@ -162,16 +172,6 @@ export default {
           image: '/img/icon-kenali-covid.svg',
           imagePosition: 'right',
           backLink: '/info/covid-19',
-          buttonType: 'outline',
-          prompt: 'Selanjutnya'
-        },
-        {
-          header: 'Informasi Vaksin',
-          title: 'Pelajari Informasi soal Vaksinasi Covid-19',
-          body: 'Ketahui lebih jauh program Vaksinasi Covid-19 sebagai upaya mencapai herd immunity sekaligus menurunkan angka penyakit dan kematian akibat Covid-19. Baca selengkapnya untuk mengetahui informasi lebih lanjut tentang Vaksinasi Covid-19 di Jawa Barat.',
-          image: '/img/icon-inject-vaccine.svg',
-          imagePosition: 'right',
-          backLink: '/vaccine',
           buttonType: 'outline',
           prompt: 'Selanjutnya'
         }

--- a/pages/info.vue
+++ b/pages/info.vue
@@ -8,7 +8,7 @@
           Informasi Lainnya
         </h2>
         <h4 class="subtitle">
-          Informasi terkait infografis, dokumen dan rilis pers seputar Covid-19 di Jawa Barat.
+          Informasi terkait infografis, dokumen dan regulasi seputar Covid-19 di Jawa Barat.
         </h4>
         <StringSearchQuery
           :placeholder="'Cari informasi'"

--- a/pages/info/covid-19/index.vue
+++ b/pages/info/covid-19/index.vue
@@ -176,7 +176,7 @@ export default {
           prompt: 'Selengkapnya'
         },
         {
-          title: 'Tetap waspada dengan menerapkan AKB',
+          title: 'Tetap waspada dengan menerapkan protokol kesehatan',
           image: '/img/icon-penerapan-AKB.svg',
           imagePosition: 'right'
         },

--- a/pages/info/documents/index.vue
+++ b/pages/info/documents/index.vue
@@ -3,8 +3,8 @@
     <section>
       <h2 class="text-xl md:text-3xl leading-normal">
         <p class="info-text">
-          Lihat dan unduh dokumen serta rilis pers seputar informasi COVID-19 di Jawa Barat.
-          Dokumen dan rilis pers yang ditampilkan berdasarkan informasi resmi dari
+          Lihat dan unduh dokumen serta regulasi seputar informasi COVID-19 di Jawa Barat.
+          Dokumen dan regulasi yang ditampilkan berdasarkan informasi resmi dari
           Pemerintah Provinsi Jawa Barat.
         </p>
       </h2>


### PR DESCRIPTION
**Task**
app.clickup.com/t/29p993f

**Changes**
- Add `backlink` to change `URL` link on anti-hoax article

**Preview**
![01-10052022](https://user-images.githubusercontent.com/9844224/167556933-f32bdfd2-f6ea-4930-820e-b5cf86b36422.gif)

**Evidence**
title: Fix detail anti-hoax article which is doesn't appear
project: Pikobar Website
participants: @maulanayuseph @maruf12 @Ibwedagama @agunghide @bangunbagustapa @doohanas 